### PR TITLE
[vincent-maillou/qttools#158] Memory use improvements

### DIFF
--- a/src/qttools/__init__.py
+++ b/src/qttools/__init__.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
+# Copyright (c) 2024-2025 ETH Zurich and the authors of the qttools package.
 
 import os
 import warnings
-from typing import Any, TypeAlias, TypeVar
+from typing import TypeAlias, TypeVar, Union
 
+import numpy as np
 from mpi4py.MPI import COMM_WORLD as global_comm
 from numpy.typing import ArrayLike
 
@@ -66,8 +67,21 @@ else:
 QTX_USE_CUPY_JIT = strtobool(os.getenv("QTX_USE_CUPY_JIT"), default=True)
 
 # Some type aliases for the array module.
-_ScalarType = TypeVar("ScalarType", bound=xp.generic, covariant=True)
-_DType = xp.dtype[_ScalarType]
-NDArray: TypeAlias = xp.ndarray[Any, _DType]
+# NOTE: CuPy is currently not type-annotated (see https://github.com/cupy/cupy/pull/9148), so we use numpy's types.
 
-__all__ = ["__version__", "xp", "sparse", "NDArray", "ArrayLike"]
+_ScalarType = TypeVar("_ScalarType", bound=np.generic, covariant=True)
+NDArray: TypeAlias = np.ndarray[tuple[int, ...], np.dtype[_ScalarType]]
+IntType: TypeAlias = Union[np.int32, np.int64]
+FloatType: TypeAlias = Union[
+    np.float16, np.float32, np.float64, np.complex64, np.complex128
+]
+
+__all__ = [
+    "__version__",
+    "xp",
+    "sparse",
+    "ArrayLike",
+    "NDArray",
+    "IntType",
+    "FloatType",
+]

--- a/src/qttools/comm/comm.py
+++ b/src/qttools/comm/comm.py
@@ -552,6 +552,10 @@ class QuatrexCommunicator:
 
         self._is_configured = True
 
+    def is_configured(self) -> bool:
+        """Checks if the communicator is configured."""
+        return self._is_configured
+
     def barrier(self):
         """Perform barrier synchronization."""
         global_comm.Barrier()

--- a/src/qttools/datastructures/dsdbcoo.py
+++ b/src/qttools/datastructures/dsdbcoo.py
@@ -59,7 +59,7 @@ class DSDBCOO(DSDBSparse):
 
     def __init__(
         self,
-        data: NDArray,
+        arg: NDArray,
         rows: NDArray,
         cols: NDArray,
         block_sizes: NDArray,
@@ -67,15 +67,19 @@ class DSDBCOO(DSDBSparse):
         return_dense: bool = True,
         symmetry: bool | None = False,
         symmetry_op: Callable = xp.conj,
+        allocate: bool = True,
+        copy: bool = True,
     ):
         """Initializes a DSDBCOO matrix."""
         super().__init__(
-            data,
+            arg,
             block_sizes,
             global_stack_shape,
             return_dense,
             symmetry=symmetry,
             symmetry_op=symmetry_op,
+            allocate=allocate,
+            copy=copy,
         )
 
         self.rows = xp.asarray(rows, dtype=xp.int32)
@@ -571,7 +575,7 @@ class DSDBCOO(DSDBSparse):
     def __neg__(self) -> "DSDBCOO":
         """Negation of the data."""
         return DSDBCOO(
-            data=-self.data,
+            arg=-self.data,
             rows=self.rows,
             cols=self.cols,
             block_sizes=self.block_sizes,
@@ -806,43 +810,6 @@ class DSDBCOO(DSDBSparse):
 
     @classmethod
     @profiler.profile(level="api")
-    def zeros_like(cls, dsdbsparse: "DSDBCOO") -> "DSDBCOO":
-        """Creates a new DSDBCOO matrix with the same shape and dtype.
-
-        All non-zero elements are set to zero, but the sparsity pattern
-        is preserved.
-
-        Parameters
-        ----------
-        dsdbcoo : DSDBCOO
-            The matrix to copy the shape and dtype from.
-
-        Returns
-        -------
-        dsdbcoo
-            The new DSDBCOO matrix.
-
-        """
-        # deepcopy can lead to issues with cupy
-        # segfaults in the tests observed
-        if dsdbsparse._data is None:
-            raise ValueError("Cannot create zeros_like from deallocated DSDBSparse.")
-
-        out = cls(
-            data=dsdbsparse.data,
-            rows=dsdbsparse.rows,
-            cols=dsdbsparse.cols,
-            block_sizes=dsdbsparse.block_sizes,
-            global_stack_shape=dsdbsparse.global_stack_shape,
-            return_dense=dsdbsparse.return_dense,
-            symmetry=dsdbsparse.symmetry,
-            symmetry_op=dsdbsparse.symmetry_op,
-        )
-        out._data[:] = 0
-        return out
-
-    @classmethod
-    @profiler.profile(level="api")
     def from_sparray(
         cls,
         sparray: sparse.spmatrix,
@@ -850,6 +817,7 @@ class DSDBCOO(DSDBSparse):
         global_stack_shape: tuple,
         symmetry: bool | None = False,
         symmetry_op: Callable = xp.conj,
+        allocate: bool = True,
     ) -> "DSDBCOO":
         """Constructs a DSDBCOO matrix from a COO matrix.
 
@@ -869,6 +837,8 @@ class DSDBCOO(DSDBSparse):
         symmetry_op : callable, optional
             The operation to use for the symmetry. Default is
             `xp.conj`.
+        allocate : bool, optional
+            Whether to allocate memory for the data. Default is True.
 
         Returns
         -------
@@ -879,13 +849,6 @@ class DSDBCOO(DSDBSparse):
 
         if comm.stack is None or comm.block is None:
             raise ValueError("Communicators must be initialized.")
-
-        # We only distribute the first dimension of the stack.
-        stack_section_sizes, __ = get_section_sizes(
-            global_stack_shape[0], comm.stack.size
-        )
-        section_size = stack_section_sizes[comm.stack.rank]
-        local_stack_shape = (section_size,) + global_stack_shape[1:]
 
         debug_gpu_memory_usage("Before tocoo conversion")
 
@@ -935,37 +898,24 @@ class DSDBCOO(DSDBSparse):
 
         debug_gpu_memory_usage("After local_mask computation")
 
-        # # Pad local data with zeros to ensure that all ranks have the
-        # # same data size for the all-to-all communication.
-        nnz_size = int(local_mask.sum())
-        # nnz_section_sizes, total_nnz_size = get_section_sizes(
-        #     nnz_size, comm.stack.size, strategy="greedy"
-        # )
-        # padded_shape = (max(stack_section_sizes), *global_stack_shape[1:], total_nnz_size)
-        # data = xp.zeros(padded_shape, dtype=coo.data.dtype)
-
-        data = xp.zeros(
-            local_stack_shape + (int(local_mask.sum()),), dtype=coo.data.dtype
-        )
-        debug_gpu_memory_usage("After data allocation")
-        if comm.rank == 0:
-            print(f"data shape: {data.shape}, nnz: {nnz_size}")
-        data[..., :] = _data[local_mask]
-        # data[: local_stack_shape[0], ..., : nnz_size] = _data[local_mask]
+        data = _data[local_mask]
         rows = _rows[local_mask] - start_idx
         cols = _cols[local_mask] - start_idx
 
-        # print(f"DSDBCOO.from_sparray | NNZ: {rows.size}, {rows.data.ptr == sparray.row.data.ptr}")
-
-        return cls(
-            data=data,
+        result = cls(
+            arg=data,
             rows=rows,
             cols=cols,
             block_sizes=block_sizes,
             global_stack_shape=global_stack_shape,
             symmetry=symmetry,
             symmetry_op=symmetry_op,
+            allocate=allocate,
+            copy=True,
         )
+
+        debug_gpu_memory_usage("After DSDBOO construction")
+        return result
 
     def to_dense(self):
         """Converts the local data to a dense array.

--- a/src/qttools/datastructures/dsdbcoo.py
+++ b/src/qttools/datastructures/dsdbcoo.py
@@ -9,6 +9,7 @@ from qttools.comm import comm
 from qttools.datastructures.dsdbsparse import DSDBSparse
 from qttools.kernels.datastructure import dsdbcoo_kernels, dsdbsparse_kernels
 from qttools.profiling.profiler import Profiler
+from qttools.utils.gpu_utils import debug_gpu_memory_usage, free_mempool
 from qttools.utils.mpi_utils import get_section_sizes
 
 profiler = Profiler()
@@ -79,6 +80,7 @@ class DSDBCOO(DSDBSparse):
 
         self.rows = xp.asarray(rows, dtype=xp.int32)
         self.cols = xp.asarray(cols, dtype=xp.int32)
+        # print(f"DSDBCOO.__init__ | NNZ: {self.rows.size}, {self.rows.data.ptr == rows.data.ptr}")
 
         self._diag_inds = xp.where(self.rows == self.cols)[0]
         self._diag_value_inds = self.rows[self._diag_inds]
@@ -885,24 +887,38 @@ class DSDBCOO(DSDBSparse):
         section_size = stack_section_sizes[comm.stack.rank]
         local_stack_shape = (section_size,) + global_stack_shape[1:]
 
+        debug_gpu_memory_usage("Before tocoo conversion")
+
         # coo: sparse.coo_matrix = sparray.tocoo().copy()
         coo: sparse.coo_matrix = sparray.tocoo()
+
+        debug_gpu_memory_usage("After tocoo conversion")
 
         # Canonicalizes the COO format.
         if symmetry:
             coo = sparse.triu(coo, format="coo")
 
+        debug_gpu_memory_usage("After symmetry conversion")
+
         if not coo.has_canonical_format:
             coo.sum_duplicates()
+            coo.eliminate_zeros()
+        free_mempool()
+
+        debug_gpu_memory_usage("After sum_duplicates")
 
         # Compute the block-sorting index.
         block_sort_index = dsdbcoo_kernels.compute_block_sort_index(
             coo.row, coo.col, block_sizes
         )
 
+        debug_gpu_memory_usage("After block_sort_index computation")
+
         _data = coo.data[block_sort_index]
         _rows = coo.row[block_sort_index]
         _cols = coo.col[block_sort_index]
+
+        debug_gpu_memory_usage("After block_sort_index application")
 
         # Determine the local slice of the data.
         # NOTE: This is arrow-wise partitioning.
@@ -917,12 +933,29 @@ class DSDBCOO(DSDBSparse):
             (_rows < end_idx) | (_cols < end_idx)
         )
 
+        debug_gpu_memory_usage("After local_mask computation")
+
+        # # Pad local data with zeros to ensure that all ranks have the
+        # # same data size for the all-to-all communication.
+        nnz_size = int(local_mask.sum())
+        # nnz_section_sizes, total_nnz_size = get_section_sizes(
+        #     nnz_size, comm.stack.size, strategy="greedy"
+        # )
+        # padded_shape = (max(stack_section_sizes), *global_stack_shape[1:], total_nnz_size)
+        # data = xp.zeros(padded_shape, dtype=coo.data.dtype)
+
         data = xp.zeros(
             local_stack_shape + (int(local_mask.sum()),), dtype=coo.data.dtype
         )
+        debug_gpu_memory_usage("After data allocation")
+        if comm.rank == 0:
+            print(f"data shape: {data.shape}, nnz: {nnz_size}")
         data[..., :] = _data[local_mask]
+        # data[: local_stack_shape[0], ..., : nnz_size] = _data[local_mask]
         rows = _rows[local_mask] - start_idx
         cols = _cols[local_mask] - start_idx
+
+        # print(f"DSDBCOO.from_sparray | NNZ: {rows.size}, {rows.data.ptr == sparray.row.data.ptr}")
 
         return cls(
             data=data,

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -2,11 +2,11 @@
 
 import itertools
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Callable, Sequence
 
 import numpy as np
 
-from qttools import ArrayLike, NDArray, sparse, xp
+from qttools import ArrayLike, FloatType, IntType, NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.profiling import Profiler, decorate_methods
 from qttools.utils.gpu_utils import empty_like_pinned, free_mempool, synchronize_device
@@ -133,14 +133,43 @@ class DSDBSparse(ABC):
 
     def __init__(
         self,
-        data: NDArray,
-        block_sizes: NDArray,
-        global_stack_shape: tuple | int,
+        arg: NDArray[FloatType] | tuple[Sequence[int], xp.dtype[FloatType]],
+        block_sizes: NDArray[IntType],
+        global_stack_shape: Sequence[int] | int,
         return_dense: bool = True,
         symmetry: bool | None = False,
-        symmetry_op: Callable = xp.conj,
+        symmetry_op: Callable[[NDArray[FloatType]], NDArray[FloatType]] = xp.conj,
+        allocate: bool = True,
+        copy: bool = True,
     ):
         """Initializes a DSBDSparse matrix."""
+
+        # Determine the stack distribution.
+        stack_section_sizes, total_stack_size = get_section_sizes(
+            global_stack_shape[0], comm.stack.size, strategy="balanced"
+        )
+        self.stack_section_sizes_offset = stack_section_sizes[comm.stack.rank]
+        self.stack_section_sizes = stack_section_sizes
+        self.total_stack_size = total_stack_size
+
+        if isinstance(arg, (list, tuple)):
+            if len(arg) != 2 or not isinstance(arg[0], (list, tuple)):
+                raise ValueError(
+                    "Argument must be a tuple of (shape, dtype) or an array."
+                )
+            data = None
+            data_shape, data_dtype = arg
+        else:
+            data = arg
+            if len(data.shape) > 1:
+                data_shape = data.shape
+            else:
+                data_shape = (
+                    self.stack_section_sizes_offset,
+                    *global_stack_shape[1:],
+                    data.shape[-1],
+                )
+            data_dtype = data.dtype
 
         # --- Things concerning stack distribution ---------------------
 
@@ -158,22 +187,15 @@ class DSDBSparse(ABC):
         self.symmetry_op = symmetry_op
 
         # Set the block and stack communicators.
-        if comm.block is None or comm.stack is None:
+        if not comm.is_configured():
             raise ValueError(
                 "Block and stack communicators must be initialized via "
                 "the BLOCK_COMM_SIZE environment variable."
             )
 
-        # Determine how the data is distributed across the stack.
-        stack_section_sizes, total_stack_size = get_section_sizes(
-            global_stack_shape[0], comm.stack.size, strategy="balanced"
-        )
-        self.stack_section_sizes_offset = stack_section_sizes[comm.stack.rank]
-        self.stack_section_sizes = stack_section_sizes
-        self.total_stack_size = total_stack_size
-
+        # Determine the nnz distribution.
         nnz_section_sizes, total_nnz_size = get_section_sizes(
-            data.shape[-1], comm.stack.size, strategy="greedy"
+            data_shape[-1], comm.stack.size, strategy="greedy"
         )
         self.nnz_section_sizes = nnz_section_sizes
         self.nnz_section_offsets = xp.hstack(([0], np.cumsum(nnz_section_sizes)))
@@ -200,14 +222,19 @@ class DSDBSparse(ABC):
             *global_stack_shape[1:],
             total_nnz_size,
         )
-        if data.shape != padded_shape:
-            self._data = xp.zeros(
-                (max(stack_section_sizes), *global_stack_shape[1:], total_nnz_size),
-                dtype=data.dtype,
-            )
-            self._data[: data.shape[0], ..., : data.shape[-1]] = data
-        else:
+
+        if not copy and data is not None and data.shape == padded_shape:
+            # If we are not copying the data and the data is already
+            # in the correct shape, we can just use it as is.
             self._data = data
+        else:
+            # Otherwise, we need to create a new array.
+            if allocate:
+                self._data = xp.zeros(padded_shape, dtype=data_dtype)
+                if data is not None:
+                    self._data[: data_shape[0], ..., : data_shape[-1]] = data
+            else:
+                self._data = None
 
         # For the weird padding convention we use, we need to keep track
         # of this padding mask.
@@ -218,8 +245,8 @@ class DSDBSparse(ABC):
             offset = i * max(stack_section_sizes)
             self._stack_padding_mask[offset : offset + size] = True
 
-        self.stack_shape = data.shape[:-1]
-        self.local_nnz = data.shape[-1]
+        self.stack_shape = data_shape[:-1]
+        self.local_nnz = data_shape[-1]
         # This is the shape of this matrix in the comm.stack.
         self.shape = self.stack_shape + (int(sum(block_sizes)), int(sum(block_sizes)))
 
@@ -247,7 +274,7 @@ class DSDBSparse(ABC):
         self._block_config: dict[int, BlockConfig] = {}
         self._add_block_config(self.num_blocks, block_sizes, block_offsets)
 
-        self.dtype = data.dtype
+        self.dtype = data_dtype
         self.return_dense = return_dense
 
         self._block_indexer = _DSDBlockIndexer(self)
@@ -834,8 +861,8 @@ class DSDBSparse(ABC):
 
     def allocate_data(self) -> None:
         """Allocates the local data."""
-        free_mempool()
         if self._data is None:
+            free_mempool()
             self._data = xp.empty(
                 (
                     int(max(self.stack_section_sizes)),
@@ -870,6 +897,7 @@ class DSDBSparse(ABC):
         global_stack_shape: tuple,
         symmetry: bool | None = False,
         symmetry_op: Callable = xp.conj,
+        allocate: bool = True,
     ) -> "DSDBSparse":
         """Creates a new DSDBSparse matrix from a scipy.sparse array.
 
@@ -892,7 +920,43 @@ class DSDBSparse(ABC):
         ...
 
     @classmethod
-    @abstractmethod
+    def empty_like(
+        cls, dsdbsparse: "DSDBSparse", allocate: bool = True
+    ) -> "DSDBSparse":
+        """Creates a new DSDBSparse matrix with the same shape and dtype.
+
+        All non-zero elements are set to zero, but the sparsity pattern
+        is preserved.
+
+        Parameters
+        ----------
+        dsdbsparse : DSDBSparse
+            The matrix to copy the shape and dtype from.
+        allocate : bool, optional
+            Whether to allocate memory for the data. Default is True.
+
+        Returns
+        -------
+        DSDBSparse
+            The new DSDBSparse matrix.
+
+        """
+        shape = dsdbsparse.stack_shape + (dsdbsparse.local_nnz,)
+        dtype = dsdbsparse.dtype
+
+        return cls(
+            arg=(shape, dtype),
+            rows=dsdbsparse.rows,
+            cols=dsdbsparse.cols,
+            block_sizes=dsdbsparse.block_sizes,
+            global_stack_shape=dsdbsparse.global_stack_shape,
+            return_dense=dsdbsparse.return_dense,
+            symmetry=dsdbsparse.symmetry,
+            symmetry_op=dsdbsparse.symmetry_op,
+            allocate=allocate,
+        )
+
+    @classmethod
     def zeros_like(cls, dsdbsparse: "DSDBSparse") -> "DSDBSparse":
         """Creates a new DSDBSparse matrix with the same shape and dtype.
 
@@ -910,7 +974,9 @@ class DSDBSparse(ABC):
             The new DSDBSparse matrix.
 
         """
-        ...
+        out = cls.empty_like(dsdbsparse, allocate=True)
+        out._data[:] = 0
+        return out
 
 
 class _DStackIndexer:

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -9,7 +9,7 @@ import numpy as np
 from qttools import ArrayLike, NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.profiling import Profiler, decorate_methods
-from qttools.utils.gpu_utils import free_mempool, synchronize_device
+from qttools.utils.gpu_utils import empty_like_pinned, free_mempool, synchronize_device
 from qttools.utils.mpi_utils import get_section_sizes
 
 profiler = Profiler()
@@ -195,11 +195,19 @@ class DSDBSparse(ABC):
 
         # Pad local data with zeros to ensure that all ranks have the
         # same data size for the all-to-all communication.
-        self._data = xp.zeros(
-            (max(stack_section_sizes), *global_stack_shape[1:], total_nnz_size),
-            dtype=data.dtype,
+        padded_shape = (
+            max(stack_section_sizes),
+            *global_stack_shape[1:],
+            total_nnz_size,
         )
-        self._data[: data.shape[0], ..., : data.shape[-1]] = data
+        if data.shape != padded_shape:
+            self._data = xp.zeros(
+                (max(stack_section_sizes), *global_stack_shape[1:], total_nnz_size),
+                dtype=data.dtype,
+            )
+            self._data[: data.shape[0], ..., : data.shape[-1]] = data
+        else:
+            self._data = data
 
         # For the weird padding convention we use, we need to keep track
         # of this padding mask.
@@ -836,6 +844,22 @@ class DSDBSparse(ABC):
                 ),
                 dtype=self.dtype,
             )
+
+    def to_host(self) -> None:
+        """Transfers the data to the host memory."""
+        if self._data is not None and xp.__name__ == "cupy":
+            host_data = empty_like_pinned(self._data)
+            self._data.get(out=host_data)
+            self._data = host_data
+            synchronize_device()
+            free_mempool()
+
+    def to_device(self) -> None:
+        """Transfers the data to the device memory."""
+        free_mempool()
+        if self._data is not None and xp.__name__ == "cupy":
+            self._data = xp.asarray(self._data)
+            synchronize_device()
 
     @classmethod
     @abstractmethod

--- a/src/qttools/utils/gpu_utils.py
+++ b/src/qttools/utils/gpu_utils.py
@@ -2,6 +2,10 @@
 
 import inspect
 
+import numpy as np
+from mpi4py import MPI
+from mpi4py.MPI import COMM_WORLD as global_comm
+
 from qttools import NDArray, xp
 from qttools.profiling import Profiler
 
@@ -342,3 +346,25 @@ def free_mempool():
     if xp.__name__ == "cupy":
         mempool = xp.get_default_memory_pool()
         mempool.free_all_blocks()
+
+
+def debug_gpu_memory_usage(msg: str = "") -> None:
+    """Prints the GPU memory usage."""
+    if xp.__name__ == "cupy":
+        free_memory, total_memory = xp.cuda.Device().mem_info
+        usage = np.array((total_memory - free_memory) / total_memory)
+        average_usage = np.empty(1)
+        max_usage = np.empty(1)
+        global_comm.Allreduce(usage, average_usage, op=MPI.SUM)
+        global_comm.Allreduce(usage, max_usage, op=MPI.MAX)
+        average_usage /= global_comm.size
+
+        if global_comm.rank == 0:
+            print(
+                f"{msg} | Rank-average device memory usage: {average_usage[0] * 100:.4f}%",
+                flush=True,
+            )
+            print(
+                f"{msg} | Max device memory usage: {max_usage[0] * 100:.4f}%",
+                flush=True,
+            )

--- a/src/qttools/utils/input_utils.py
+++ b/src/qttools/utils/input_utils.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from qttools import NDArray, _DType, sparse, xp
+from qttools.utils.gpu_utils import debug_gpu_memory_usage, free_mempool
 
 
 def read_hr_dat(
@@ -293,6 +294,7 @@ def create_hamiltonian(
     cutoff: float = xp.inf,
     coords: NDArray = None,
     lattice_vectors: NDArray = None,
+    format: str = "coo",
 ) -> list[NDArray]:
     """Creates a block-tridiagonal Hamiltonian matrix from a Wannier Hamiltonian.
     The transport cell (same as supercell) is the cell that is repeated in the transport direction,
@@ -374,9 +376,13 @@ def create_hamiltonian(
     upper_ind = tuple([1 if i == transport_dir else 0 for i in range(3)])
     lower_ind = tuple([-1 if i == transport_dir else 0 for i in range(3)])
 
+    debug_gpu_memory_usage("Before creating Hamiltonian blocks")
+
     diag_block = get_hamiltonian_block(hR, transport_cell, (0, 0, 0))
     upper_block = get_hamiltonian_block(hR, transport_cell, upper_ind)
     lower_block = get_hamiltonian_block(hR, transport_cell, lower_ind)
+
+    debug_gpu_memory_usage("After creating Hamiltonian blocks")
 
     # Enforce cutoff.
     if coords is not None and cutoff < xp.inf and lattice_vectors is not None:
@@ -402,11 +408,14 @@ def create_hamiltonian(
         diag_block = sparse.coo_matrix(diag_block)
         upper_block = sparse.coo_matrix(upper_block)
         lower_block = sparse.coo_matrix(lower_block)
+
+        debug_gpu_memory_usage("After creating sparse Hamiltonian blocks")
         # Canoncialize the sparse matrices.
         # NOTE: Not sure if this is necessary.
         for mat in [diag_block, upper_block, lower_block]:
             if mat.has_canonical_format is False:
                 mat.sum_duplicates()
+                mat.eliminate_zeros()
         # Create the block-tridiagonal matrix.
         num_blocks = block_end - block_start
         offsets = xp.arange(block_start, block_end) * diag_block.shape[0]
@@ -430,24 +439,57 @@ def create_hamiltonian(
         upper_cols += diag_block.shape[0]
         lower_rows += diag_block.shape[0]
 
+        matrix_shape = num_transport_cells * diag_block.shape[0]
+        block_sizes = xp.ones(num_blocks, dtype=int) * diag_block.shape[0]
+        del diag_block, upper_block, lower_block
+        free_mempool()
+
+        debug_gpu_memory_usage("After tiling sparse Hamiltonian blocks")
+
         full_rows = xp.hstack([diag_rows, upper_rows, lower_rows])
         full_cols = xp.hstack([diag_cols, upper_cols, lower_cols])
         full_data = xp.hstack([diag_data, upper_data, lower_data])
+
+        del diag_rows, diag_cols, diag_data
+        del upper_rows, upper_cols, upper_data
+        del lower_rows, lower_cols, lower_data
+        free_mempool()
+
+        debug_gpu_memory_usage("After stacking sparse Hamiltonian blocks")
         # Remove the fishtail at the end of the matrix.
-        matrix_shape = num_transport_cells * diag_block.shape[0]
+        # matrix_shape = num_transport_cells * diag_block.shape[0]
         valid_mask = (full_cols < matrix_shape) & (full_rows < matrix_shape)
         full_rows = full_rows[valid_mask]
         full_cols = full_cols[valid_mask]
         full_data = full_data[valid_mask]
+
+        del valid_mask
+        free_mempool()
+
+        debug_gpu_memory_usage("After removing fishtail from sparse Hamiltonian blocks")
         # Also return the block sizes.
-        block_sizes = xp.ones(num_blocks, dtype=int) * diag_block.shape[0]
-        return (
-            sparse.coo_matrix(
+        # block_sizes = xp.ones(num_blocks, dtype=int) * diag_block.shape[0]
+        if format == "csr":
+            # Convert to CSR format.
+            result = sparse.csr_matrix(
                 (full_data, (full_rows, full_cols)),
                 shape=(matrix_shape, matrix_shape),
-            ),
-            block_sizes,
-        )
+            )
+        elif format == "coo":
+            result = (
+                sparse.coo_matrix(
+                    (full_data, (full_rows, full_cols)),
+                    shape=(matrix_shape, matrix_shape),
+                ),
+                block_sizes,
+            )
+        else:
+            raise ValueError(f"Unsupported format: {format}")
+
+        del full_rows, full_cols, full_data
+        free_mempool()
+        debug_gpu_memory_usage("After creating full sparse Hamiltonian matrix")
+        return result
     else:
         # Returns the block-tridiagonal Hamiltonian matrix as a tuple of arrays.
         diag = xp.tile(diag_block, (block_end - block_start, 1))

--- a/src/qttools/utils/input_utils.py
+++ b/src/qttools/utils/input_utils.py
@@ -5,12 +5,15 @@ from pathlib import Path
 
 import numpy as np
 
-from qttools import NDArray, _DType, sparse, xp
+from qttools import FloatType, NDArray, sparse, xp
 from qttools.utils.gpu_utils import debug_gpu_memory_usage, free_mempool
 
 
 def read_hr_dat(
-    path: Path, return_all: bool = False, dtype: _DType = xp.complex128, read_fast=False
+    path: Path,
+    return_all: bool = False,
+    dtype: xp.dtype[FloatType] = xp.complex128,
+    read_fast=False,
 ) -> tuple[NDArray, ...]:
     """Parses the contents of a `seedname_hr.dat` file.
 

--- a/src/qttools/utils/mpi_utils.py
+++ b/src/qttools/utils/mpi_utils.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
 
 from pathlib import Path
+from typing import Any
 
 import scipy.sparse as sps
 from mpi4py import MPI
-from mpi4py.MPI import COMM_WORLD as comm
+from mpi4py.MPI import COMM_WORLD
 from mpi4py.util import pkl5
 
 from qttools import NDArray, sparse, xp
 from qttools.profiling import Profiler
 
 profiler = Profiler()
-comm = pkl5.Intracomm(comm)
+comm = pkl5.Intracomm(COMM_WORLD)
 
 
 @profiler.profile(level="debug")
@@ -19,7 +20,7 @@ def get_section_sizes(
     num_elements: int,
     num_sections: int = comm.size,
     strategy: str = "balanced",
-) -> tuple[list, int]:
+) -> tuple[list[int], int]:
     """Computes the number of un-evenly divided elements per section.
 
     Parameters
@@ -70,7 +71,7 @@ def get_section_sizes(
 
 
 @profiler.profile(level="debug")
-def distributed_load(path: Path) -> sparse.spmatrix | NDArray:
+def distributed_load(path: Path) -> sparse.spmatrix | NDArray[Any]:
     """Loads an array from disk and distributes it to all ranks.
 
     Parameters
@@ -110,7 +111,7 @@ def distributed_load(path: Path) -> sparse.spmatrix | NDArray:
 
 
 @profiler.profile(level="debug")
-def get_local_slice(global_array: NDArray, comm: MPI.Comm = comm) -> NDArray:
+def get_local_slice(global_array: NDArray[Any], comm: MPI.Comm = comm) -> NDArray[Any]:
     """Returns the local slice of a distributed array.
 
     Parameters

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -11,7 +11,7 @@ from mpi4py.MPI import COMM_WORLD as global_comm
 from qttools import NDArray, xp
 from qttools.comm import comm
 from qttools.profiling import Profiler
-from qttools.utils.gpu_utils import get_host, synchronize_device
+from qttools.utils.gpu_utils import debug_gpu_memory_usage, get_host, synchronize_device
 from qttools.utils.input_utils import create_coordinate_grid
 from qttools.utils.mpi_utils import distributed_load, get_section_sizes
 
@@ -144,7 +144,8 @@ class SCBAData:
             block_sizes=block_sizes,
             global_stack_shape=electron_energies.shape,
         )
-        self.g_retarded.data[:] = 0.0  # Initialize to zero.
+        # self.g_retarded.data[:] = 0.0  # Initialize to zero.
+        self.g_retarded.free_data()
 
         self.g_lesser = dsdbsparse_type.from_sparray(
             self.sparsity_pattern.astype(xp.complex128),
@@ -153,15 +154,27 @@ class SCBAData:
             symmetry=quatrex_config.scba.symmetric,
             symmetry_op=lambda a: -a.conj(),
         )
+        # self.g_lesser = dsdbsparse_type.zeros_like(self.g_retarded)
+        # self.g_retarded.free_data()
+        # self.g_lesser.symmetry = quatrex_config.scba.symmetric
+        # self.g_lesser.symmetry_op = lambda a: -a.conj()
+        # self.g_lesser.free_data()
         self.g_greater = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.g_greater.free_data()
 
         self.sigma_lesser_prev = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_lesser_prev.free_data()
         self.sigma_lesser = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_lesser.free_data()
         self.sigma_greater_prev = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_greater_prev.free_data()
         self.sigma_greater = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_greater.free_data()
 
         self.sigma_retarded_prev = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_retarded_prev.free_data()
         self.sigma_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_retarded.free_data()
         if quatrex_config.scba.symmetric:
             self.sigma_retarded.symmetry_op = lambda a: a
             self.sigma_retarded_prev.symmetry_op = lambda a: a
@@ -172,8 +185,11 @@ class SCBAData:
             # space). However, we need to change the block sizes of the
             # screened Coulomb interaction.
             self.p_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
+            self.p_retarded.free_data()
             self.p_lesser = dsdbsparse_type.zeros_like(self.g_lesser)
+            self.p_lesser.free_data()
             self.p_greater = dsdbsparse_type.zeros_like(self.g_lesser)
+            self.p_greater.free_data()
 
             num_connected_blocks = quatrex_config.coulomb_screening.num_connected_blocks
             if num_connected_blocks == "auto":
@@ -198,6 +214,10 @@ class SCBAData:
                 symmetry_op=lambda a: -a.conj(),
             )
             self.w_greater = dsdbsparse_type.zeros_like(self.w_lesser)
+            self.w_lesser.free_data()
+            self.w_greater.free_data()
+
+        self.g_lesser.free_data()
 
         # TODO: The interactions with photons and phonons are not yet
         # implemented.
@@ -288,12 +308,16 @@ class SCBA:
 
         self.compute_config = compute_config
 
+        debug_gpu_memory_usage("Before SCBAData dummy initialization")
+
         self.observables = Observables()
         electron_energies = xp.zeros((comm.size,))
         self.data = SCBAData(
             quatrex_config, compute_config, electron_energies=electron_energies
         )  # dummy data
         self.mixing_factor = self.quatrex_config.scba.mixing_factor
+
+        debug_gpu_memory_usage("After SCBAData dummy initialization")
 
         # ----- Electrons ----------------------------------------------
         if (self.quatrex_config.electron.energy_window_max is not None) and (
@@ -357,12 +381,16 @@ class SCBA:
                 f"Each comm.block has {num_energies_per_rank} grid points.", flush=True
             )
 
+        debug_gpu_memory_usage("Before ElectronSolver initialization")
+
         self.electron_solver = ElectronSolver(
             self.quatrex_config,
             self.compute_config,
             self.electron_energies,
             sparsity_pattern=self.data.sparsity_pattern,
         )
+
+        debug_gpu_memory_usage("After ElectronSolver initialization")
 
         # ----- Coulomb screening --------------------------------------
         if self.quatrex_config.scba.coulomb_screening:
@@ -435,6 +463,7 @@ class SCBA:
         self.data = SCBAData(
             quatrex_config, compute_config, electron_energies=self.electron_energies
         )  # real data
+        self.data.sparsity_pattern = None
 
     def _determine_electron_energy_window(
         self, quatrex_config: QuatrexConfig, compute_config: ComputeConfig
@@ -639,11 +668,19 @@ class SCBA:
                 flush=True,
             )
 
-        self.data.p_lesser.free_data()
-        self.data.p_greater.free_data()
-        self.data.p_retarded.free_data()
+        # self.data.p_lesser.free_data()
+        # self.data.p_greater.free_data()
+        # self.data.p_retarded.free_data()
 
         t_sigma_fock_start = time.perf_counter()
+        for m in (
+            self.data.sigma_lesser,
+            self.data.sigma_greater,
+            self.data.sigma_retarded,
+        ):
+            m.allocate_data()
+            m.dtranspose(discard=True)  # These can be safely discarded.
+            assert m.distribution_state == "nnz"
         self.sigma_fock.compute(
             self.data.g_lesser,
             out=(self.data.sigma_retarded,),
@@ -859,6 +896,20 @@ class SCBA:
         """Runs the SCBA to convergence."""
         print("Entering SCBA loop...", flush=True) if comm.rank == 0 else None
 
+        self.data.g_retarded.allocate_data()
+        self.data.g_lesser.allocate_data()
+        self.data.g_greater.allocate_data()
+        self.data.sigma_lesser.allocate_data()
+        self.data.sigma_greater.allocate_data()
+        self.data.sigma_retarded.allocate_data()
+        self.data.sigma_lesser_prev.allocate_data()
+        self.data.sigma_greater_prev.allocate_data()
+        self.data.sigma_retarded_prev.allocate_data()
+
+        self.data.sigma_lesser.data[:] = 0.0
+        self.data.sigma_greater.data[:] = 0.0
+        self.data.sigma_retarded.data[:] = 0.0
+
         for i in range(self.quatrex_config.scba.max_iterations):
             print(f"Iteration {i}", flush=True) if comm.rank == 0 else None
             # append for iteration time
@@ -866,13 +917,40 @@ class SCBA:
             comm.barrier()
             t_iteration_start = time.perf_counter()
 
+            # Stash current into previous self-energy buffer.
+            t_stash_start = time.perf_counter()
+            self._stash_sigma()
+            self.data.sigma_retarded.free_data()
+            self.data.sigma_lesser.free_data()
+            self.data.sigma_greater.free_data()
+            synchronize_device()
+            t_stash_end = time.perf_counter()
+            comm.barrier()
+            t_stash_end_all = time.perf_counter()
+            if comm.rank == 0:
+                print(
+                    f"Time for stashing: {t_stash_end - t_stash_start:.3f} s",
+                    flush=True,
+                )
+                print(
+                    f"Time for stashing all: {t_stash_end_all - t_stash_start:.3f} s",
+                    flush=True,
+                )
+
             t_solve_start = time.perf_counter()
+            self.data.g_retarded.allocate_data()
             self.electron_solver.solve(
-                self.data.sigma_lesser,
-                self.data.sigma_greater,
-                self.data.sigma_retarded,
+                # self.data.sigma_lesser,
+                # self.data.sigma_greater,
+                # self.data.sigma_retarded,
+                self.data.sigma_lesser_prev,
+                self.data.sigma_greater_prev,
+                self.data.sigma_retarded_prev,
                 out=(self.data.g_lesser, self.data.g_greater, self.data.g_retarded),
             )
+            self.data.sigma_lesser_prev.to_host()
+            self.data.sigma_greater_prev.to_host()
+            self.data.sigma_retarded_prev.to_host()
             synchronize_device()
             t_solve_end = time.perf_counter()
             comm.barrier()
@@ -889,6 +967,7 @@ class SCBA:
 
             t_oberservables_start = time.perf_counter()
             self._compute_electron_observables()
+            self.data.g_retarded.free_data()
             synchronize_device()
             t_oberservables_end = time.perf_counter()
             comm.barrier()
@@ -904,22 +983,22 @@ class SCBA:
                     flush=True,
                 )
 
-            # Stash current into previous self-energy buffer.
-            t_stash_start = time.perf_counter()
-            self._stash_sigma()
-            synchronize_device()
-            t_stash_end = time.perf_counter()
-            comm.barrier()
-            t_stash_end_all = time.perf_counter()
-            if comm.rank == 0:
-                print(
-                    f"Time for swapping: {t_stash_end - t_stash_start:.3f} s",
-                    flush=True,
-                )
-                print(
-                    f"Time for swapping all: {t_stash_end_all - t_stash_start:.3f} s",
-                    flush=True,
-                )
+            # # Stash current into previous self-energy buffer.
+            # t_stash_start = time.perf_counter()
+            # self._stash_sigma()
+            # synchronize_device()
+            # t_stash_end = time.perf_counter()
+            # comm.barrier()
+            # t_stash_end_all = time.perf_counter()
+            # if comm.rank == 0:
+            #     print(
+            #         f"Time for swapping: {t_stash_end - t_stash_start:.3f} s",
+            #         flush=True,
+            #     )
+            #     print(
+            #         f"Time for swapping all: {t_stash_end_all - t_stash_start:.3f} s",
+            #         flush=True,
+            #     )
 
             # Transpose to nnz distribution.
             # NOTE: While computing all interactions, we only ever need
@@ -929,13 +1008,13 @@ class SCBA:
             for m in (self.data.g_lesser, self.data.g_greater):
                 m.dtranspose(discard=False)  # This must not be discarded.
                 assert m.distribution_state == "nnz"
-            for m in (
-                self.data.sigma_lesser,
-                self.data.sigma_greater,
-                self.data.sigma_retarded,
-            ):
-                m.dtranspose(discard=True)  # These can be safely discarded.
-                assert m.distribution_state == "nnz"
+            # for m in (
+            #     self.data.sigma_lesser,
+            #     self.data.sigma_greater,
+            #     self.data.sigma_retarded,
+            # ):
+            #     m.dtranspose(discard=True)  # These can be safely discarded.
+            #     assert m.distribution_state == "nnz"
             synchronize_device()
             t_end_transpose = time.perf_counter()
             comm.barrier()
@@ -1015,6 +1094,9 @@ class SCBA:
                 )
 
             t_convergence_start = time.perf_counter()
+            self.data.sigma_lesser_prev.to_device()
+            self.data.sigma_greater_prev.to_device()
+            self.data.sigma_retarded_prev.to_device()
             if self._has_converged():
                 if comm.rank == 0:
                     print(f"SCBA converged after {i} iterations.", flush=True)

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -11,7 +11,13 @@ from mpi4py.MPI import COMM_WORLD as global_comm
 from qttools import NDArray, xp
 from qttools.comm import comm
 from qttools.profiling import Profiler
-from qttools.utils.gpu_utils import debug_gpu_memory_usage, get_host, synchronize_device
+from qttools.utils.gpu_utils import (
+    create_stream,
+    debug_gpu_memory_usage,
+    get_host,
+    synchronize_device,
+    synchronize_stream,
+)
 from qttools.utils.input_utils import create_coordinate_grid
 from qttools.utils.mpi_utils import distributed_load, get_section_sizes
 
@@ -456,6 +462,8 @@ class SCBA:
         )  # real data
         self.data.sparsity_pattern = None
 
+        self._copy_stream = create_stream()
+
     def _determine_electron_energy_window(
         self, quatrex_config: QuatrexConfig, compute_config: ComputeConfig
     ):
@@ -502,9 +510,12 @@ class SCBA:
         self.data.sigma_greater_prev.data[:] = self.data.sigma_greater.data
         self.data.sigma_retarded_prev.data[:] = self.data.sigma_retarded.data
 
-        self.data.sigma_retarded.data[:] = 0.0
-        self.data.sigma_lesser.data[:] = 0.0
-        self.data.sigma_greater.data[:] = 0.0
+        self.data.sigma_retarded.free_data()
+        self.data.sigma_lesser.free_data()
+        self.data.sigma_greater.free_data()
+        # self.data.sigma_retarded.data[:] = 0.0
+        # self.data.sigma_lesser.data[:] = 0.0
+        # self.data.sigma_greater.data[:] = 0.0
 
     @profiler.profile(level="api")
     def _update_sigma(self) -> None:
@@ -595,16 +606,24 @@ class SCBA:
     def _compute_coulomb_screening_interaction(self):
         """Computes the Coulomb screening interaction."""
 
+        t_polarization_start = time.perf_counter()
         self.data.p_greater.allocate_data()
         self.data.p_lesser.allocate_data()
         self.data.p_retarded.allocate_data()
-
-        t_polarization_start = time.perf_counter()
+        self.data.g_lesser.to_host(
+            delete_device=False, stream=self._copy_stream, sync=False
+        )
+        self.data.g_greater.to_host(
+            delete_device=False, stream=self._copy_stream, sync=False
+        )
         self.p_coulomb_screening.compute(
             self.data.g_lesser,
             self.data.g_greater,
             out=(self.data.p_lesser, self.data.p_greater, self.data.p_retarded),
         )
+        if xp.__name__ == "cupy":
+            self.data.g_lesser.free_data()
+            self.data.g_greater.free_data()
         synchronize_device()
         t_polarization_end = time.perf_counter()
         comm.barrier()
@@ -619,12 +638,9 @@ class SCBA:
                 flush=True,
             )
 
-        self.data.g_lesser.to_host()
-        self.data.g_greater.to_host()
+        t_coulomb_start = time.perf_counter()
         self.data.w_greater.allocate_data()
         self.data.w_lesser.allocate_data()
-
-        t_coulomb_start = time.perf_counter()
         self.coulomb_screening_solver.solve(
             self.data.p_lesser,
             self.data.p_greater,
@@ -661,13 +677,16 @@ class SCBA:
                 flush=True,
             )
 
+        t_sigma_fock_start = time.perf_counter()
         self.data.p_lesser.free_data()
         self.data.p_greater.free_data()
         self.data.p_retarded.free_data()
-
-        t_sigma_fock_start = time.perf_counter()
-        self.data.g_lesser.to_device()
-        self.data.g_greater.to_device()
+        self.data.g_lesser.to_device(
+            delete_host=False, stream=self._copy_stream, sync=False
+        )
+        self.data.g_greater.to_device(
+            delete_host=False, stream=self._copy_stream, sync=False
+        )
         for m in (
             self.data.sigma_lesser,
             self.data.sigma_greater,
@@ -676,6 +695,7 @@ class SCBA:
             m.allocate_data()
             m.dtranspose(discard=True)  # These can be safely discarded.
             assert m.distribution_state == "nnz"
+        synchronize_stream(self._copy_stream)
         self.sigma_fock.compute(
             self.data.g_lesser,
             out=(self.data.sigma_retarded,),
@@ -706,6 +726,8 @@ class SCBA:
                 self.data.sigma_retarded,
             ),
         )
+        self.data.w_greater.free_data()
+        self.data.w_lesser.free_data()
         synchronize_device()
         t_sigma_end = time.perf_counter()
         comm.barrier()
@@ -719,9 +741,6 @@ class SCBA:
                 f"  Time for Coulomb screening self-energy all: {t_sigma_end_all - t_sigma_start:.3f} s",
                 flush=True,
             )
-
-        self.data.w_greater.free_data()
-        self.data.w_lesser.free_data()
 
     @profiler.profile(level="debug")
     def _compute_electron_observables(self) -> None:
@@ -914,9 +933,6 @@ class SCBA:
             # Stash current into previous self-energy buffer.
             t_stash_start = time.perf_counter()
             self._stash_sigma()
-            self.data.sigma_retarded.free_data()
-            self.data.sigma_lesser.free_data()
-            self.data.sigma_greater.free_data()
             synchronize_device()
             t_stash_end = time.perf_counter()
             comm.barrier()
@@ -939,9 +955,10 @@ class SCBA:
                 self.data.sigma_retarded_prev,
                 out=(self.data.g_lesser, self.data.g_greater, self.data.g_retarded),
             )
-            self.data.sigma_lesser_prev.to_host()
-            self.data.sigma_greater_prev.to_host()
-            self.data.sigma_retarded_prev.to_host()
+            if xp.__name__ == "cupy":
+                self.data.sigma_lesser_prev.free_data()
+                self.data.sigma_greater_prev.free_data()
+                self.data.sigma_retarded_prev.free_data()
             synchronize_device()
             t_solve_end = time.perf_counter()
             comm.barrier()
@@ -1035,6 +1052,15 @@ class SCBA:
 
             # Transpose back to stack distribution.
             t_transpose_sigma_start = time.perf_counter()
+            self.data.sigma_lesser_prev.to_device(
+                delete_host=False, stream=self._copy_stream, sync=False
+            )
+            self.data.sigma_greater_prev.to_device(
+                delete_host=False, stream=self._copy_stream, sync=False
+            )
+            self.data.sigma_retarded_prev.to_device(
+                delete_host=False, stream=self._copy_stream, sync=False
+            )
             for m in (self.data.g_lesser, self.data.g_greater):
                 m.dtranspose(discard=True)  # These can be safely discarded.
                 assert m.distribution_state == "stack"
@@ -1061,9 +1087,6 @@ class SCBA:
                 )
 
             t_convergence_start = time.perf_counter()
-            self.data.sigma_lesser_prev.to_device()
-            self.data.sigma_greater_prev.to_device()
-            self.data.sigma_retarded_prev.to_device()
             if self._has_converged():
                 if comm.rank == 0:
                     print(f"SCBA converged after {i} iterations.", flush=True)

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -934,9 +934,6 @@ class SCBA:
             t_solve_start = time.perf_counter()
             self.data.g_retarded.allocate_data()
             self.electron_solver.solve(
-                # self.data.sigma_lesser,
-                # self.data.sigma_greater,
-                # self.data.sigma_retarded,
                 self.data.sigma_lesser_prev,
                 self.data.sigma_greater_prev,
                 self.data.sigma_retarded_prev,
@@ -977,23 +974,6 @@ class SCBA:
                     flush=True,
                 )
 
-            # # Stash current into previous self-energy buffer.
-            # t_stash_start = time.perf_counter()
-            # self._stash_sigma()
-            # synchronize_device()
-            # t_stash_end = time.perf_counter()
-            # comm.barrier()
-            # t_stash_end_all = time.perf_counter()
-            # if comm.rank == 0:
-            #     print(
-            #         f"Time for swapping: {t_stash_end - t_stash_start:.3f} s",
-            #         flush=True,
-            #     )
-            #     print(
-            #         f"Time for swapping all: {t_stash_end_all - t_stash_start:.3f} s",
-            #         flush=True,
-            #     )
-
             # Transpose to nnz distribution.
             # NOTE: While computing all interactions, we only ever need
             # to access the Green's function and the self-energies in
@@ -1002,13 +982,6 @@ class SCBA:
             for m in (self.data.g_lesser, self.data.g_greater):
                 m.dtranspose(discard=False)  # This must not be discarded.
                 assert m.distribution_state == "nnz"
-            # for m in (
-            #     self.data.sigma_lesser,
-            #     self.data.sigma_greater,
-            #     self.data.sigma_retarded,
-            # ):
-            #     m.dtranspose(discard=True)  # These can be safely discarded.
-            #     assert m.distribution_state == "nnz"
             synchronize_device()
             t_end_transpose = time.perf_counter()
             comm.barrier()

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -143,38 +143,31 @@ class SCBAData:
             self.sparsity_pattern.astype(xp.complex128),
             block_sizes=block_sizes,
             global_stack_shape=electron_energies.shape,
+            allocate=False,
         )
-        # self.g_retarded.data[:] = 0.0  # Initialize to zero.
-        self.g_retarded.free_data()
-
         self.g_lesser = dsdbsparse_type.from_sparray(
             self.sparsity_pattern.astype(xp.complex128),
             block_sizes=block_sizes,
             global_stack_shape=electron_energies.shape,
             symmetry=quatrex_config.scba.symmetric,
             symmetry_op=lambda a: -a.conj(),
+            allocate=False,
         )
-        # self.g_lesser = dsdbsparse_type.zeros_like(self.g_retarded)
-        # self.g_retarded.free_data()
-        # self.g_lesser.symmetry = quatrex_config.scba.symmetric
-        # self.g_lesser.symmetry_op = lambda a: -a.conj()
-        # self.g_lesser.free_data()
-        self.g_greater = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.g_greater.free_data()
+        self.g_greater = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
 
-        self.sigma_lesser_prev = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_lesser_prev.free_data()
-        self.sigma_lesser = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_lesser.free_data()
-        self.sigma_greater_prev = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_greater_prev.free_data()
-        self.sigma_greater = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_greater.free_data()
+        self.sigma_lesser_prev = dsdbsparse_type.empty_like(
+            self.g_lesser, allocate=False
+        )
+        self.sigma_lesser = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
+        self.sigma_greater_prev = dsdbsparse_type.empty_like(
+            self.g_lesser, allocate=False
+        )
+        self.sigma_greater = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
+        self.sigma_retarded_prev = dsdbsparse_type.empty_like(
+            self.g_lesser, allocate=False
+        )
+        self.sigma_retarded = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
 
-        self.sigma_retarded_prev = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_retarded_prev.free_data()
-        self.sigma_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_retarded.free_data()
         if quatrex_config.scba.symmetric:
             self.sigma_retarded.symmetry_op = lambda a: a
             self.sigma_retarded_prev.symmetry_op = lambda a: a
@@ -184,12 +177,9 @@ class SCBAData:
             # the electronic system (the interactions are local in real
             # space). However, we need to change the block sizes of the
             # screened Coulomb interaction.
-            self.p_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
-            self.p_retarded.free_data()
-            self.p_lesser = dsdbsparse_type.zeros_like(self.g_lesser)
-            self.p_lesser.free_data()
-            self.p_greater = dsdbsparse_type.zeros_like(self.g_lesser)
-            self.p_greater.free_data()
+            self.p_retarded = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
+            self.p_lesser = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
+            self.p_greater = dsdbsparse_type.empty_like(self.g_lesser, allocate=False)
 
             num_connected_blocks = quatrex_config.coulomb_screening.num_connected_blocks
             if num_connected_blocks == "auto":
@@ -212,12 +202,9 @@ class SCBAData:
                 global_stack_shape=electron_energies.shape,
                 symmetry=quatrex_config.scba.symmetric,
                 symmetry_op=lambda a: -a.conj(),
+                allocate=False,
             )
-            self.w_greater = dsdbsparse_type.zeros_like(self.w_lesser)
-            self.w_lesser.free_data()
-            self.w_greater.free_data()
-
-        self.g_lesser.free_data()
+            self.w_greater = dsdbsparse_type.empty_like(self.w_lesser, allocate=False)
 
         # TODO: The interactions with photons and phonons are not yet
         # implemented.
@@ -412,23 +399,27 @@ class SCBA:
                 self.electron_energies,
                 sparsity_pattern=self.data.sparsity_pattern,
             )
+            debug_gpu_memory_usage("After SigmaFock initialization")
             # NOTE: No sparsity information required here.
             self.p_coulomb_screening = PCoulombScreening(
                 self.quatrex_config,
                 self.compute_config,
                 self.coulomb_screening_energies,
             )
+            debug_gpu_memory_usage("After PCoulombScreening initialization")
             self.coulomb_screening_solver = CoulombScreeningSolver(
                 self.quatrex_config,
                 self.compute_config,
                 self.coulomb_screening_energies,
                 sparsity_pattern=self.data.sparsity_pattern,
             )
+            debug_gpu_memory_usage("After CoulombScreeningSolver initialization")
             self.sigma_coulomb_screening = SigmaCoulombScreening(
                 self.quatrex_config,
                 self.compute_config,
                 self.electron_energies,
             )
+            debug_gpu_memory_usage("After SigmaCoulombScreening initialization")
 
         # ----- Photons ------------------------------------------------
         if self.quatrex_config.scba.photon:
@@ -628,6 +619,8 @@ class SCBA:
                 flush=True,
             )
 
+        self.data.g_lesser.to_host()
+        self.data.g_greater.to_host()
         self.data.w_greater.allocate_data()
         self.data.w_lesser.allocate_data()
 
@@ -668,11 +661,13 @@ class SCBA:
                 flush=True,
             )
 
-        # self.data.p_lesser.free_data()
-        # self.data.p_greater.free_data()
-        # self.data.p_retarded.free_data()
+        self.data.p_lesser.free_data()
+        self.data.p_greater.free_data()
+        self.data.p_retarded.free_data()
 
         t_sigma_fock_start = time.perf_counter()
+        self.data.g_lesser.to_device()
+        self.data.g_greater.to_device()
         for m in (
             self.data.sigma_lesser,
             self.data.sigma_greater,
@@ -896,7 +891,6 @@ class SCBA:
         """Runs the SCBA to convergence."""
         print("Entering SCBA loop...", flush=True) if comm.rank == 0 else None
 
-        self.data.g_retarded.allocate_data()
         self.data.g_lesser.allocate_data()
         self.data.g_greater.allocate_data()
         self.data.sigma_lesser.allocate_data()

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -9,7 +9,12 @@ from qttools.datastructures import DSDBSparse
 from qttools.datastructures.routines import bd_matmul_distr, bd_sandwich_distr
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler, decorate_methods
-from qttools.utils.gpu_utils import get_host, synchronize_device
+from qttools.utils.gpu_utils import (
+    debug_gpu_memory_usage,
+    free_mempool,
+    get_host,
+    synchronize_device,
+)
 from qttools.utils.input_utils import create_hamiltonian, cutoff_hr
 from qttools.utils.mpi_utils import distributed_load, get_local_slice, get_section_sizes
 from qttools.utils.sparse_utils import product_sparsity_pattern_dsdbsparse
@@ -207,13 +212,26 @@ class CoulombScreeningSolver(SubsystemSolver):
         )
         self.coulomb_matrix.dtype = xp.complex128
 
+        # self.coulomb_matrix = None
+        debug_gpu_memory_usage("Before loading Coulomb matrix")
+        free_mempool()
+        debug_gpu_memory_usage("After freeing memory pool")
+
         self.coulomb_matrix += coulomb_matrix_sparray
+        # self.coulomb_matrix = compute_config.dsdbsparse_type.from_sparray(
+        #     coulomb_matrix_sparray,
+        #     block_sizes=self.small_block_sizes,
+        #     global_stack_shape=(comm.stack.size,),
+        #     symmetry=quatrex_config.scba.symmetric,
+        #     symmetry_op=xp.conj,
+        # )
         # Explicitely try to free the memory for the sparsity pattern.
         del coulomb_matrix_sparray
 
         # Make sure that the Coulomb matrix is Hermitian.
         self.coulomb_matrix.symmetrize()
         self.coulomb_matrix.data /= quatrex_config.coulomb_screening.epsilon_r
+        self.coulomb_matrix.to_host()
 
         # Boundary conditions.
         self.left_occupancies = bose_einstein(
@@ -516,7 +534,9 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         # Assemble the system matrix (Includes matrix multiplication).
         t_assembly_start = time.perf_counter()
+        self.coulomb_matrix.to_device()
         self._assemble_system_matrix(p_retarded)
+        p_retarded.free_data()
         synchronize_device()
         t_assembly_end = time.perf_counter()
         comm.barrier()
@@ -542,6 +562,7 @@ class CoulombScreeningSolver(SubsystemSolver):
             end_block=end_block,
             spillover_correction=True,
         )
+        p_lesser.free_data()
         bd_sandwich_distr(
             self.coulomb_matrix,
             p_greater,
@@ -550,6 +571,8 @@ class CoulombScreeningSolver(SubsystemSolver):
             end_block=end_block,
             spillover_correction=True,
         )
+        p_greater.free_data()
+        self.coulomb_matrix.to_host()
         synchronize_device()
         t_sandwich_end = time.perf_counter()
         comm.barrier()

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -3,7 +3,7 @@
 import time
 
 import numpy as np
-from qttools import NDArray, _DType, sparse, xp
+from qttools import FloatType, NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
 from qttools.datastructures.routines import bd_matmul_distr, bd_sandwich_distr
@@ -34,7 +34,7 @@ profiler = Profiler()
 
 @profiler.profile(level="debug")
 def _compute_sparsity_pattern(
-    *matrices: DSDBSparse, dtype: _DType = None
+    *matrices: DSDBSparse, dtype: xp.dtype[FloatType] = None
 ) -> sparse.coo_matrix:
     """Computes the sparsity pattern of the product of several DSDBSparse matrices."""
     num_blocks = matrices[0].num_blocks
@@ -149,9 +149,9 @@ class CoulombScreeningSolver(SubsystemSolver):
             v_times_p_sparsity_pattern.astype(xp.complex128),
             block_sizes=self.block_sizes,
             global_stack_shape=self.energies.shape,
+            allocate=False,
         )
-        self.system_matrix.free_data()
-        # Explicitely try to free the memory for the sparsity pattern.
+        # Explicitly try to free the memory for the sparsity pattern.
         del v_times_p_sparsity_pattern
 
         l_sparsity_pattern = _compute_sparsity_pattern(
@@ -168,12 +168,14 @@ class CoulombScreeningSolver(SubsystemSolver):
             global_stack_shape=self.energies.shape,
             symmetry=quatrex_config.scba.symmetric,
             symmetry_op=lambda a: -a.conj(),
+            allocate=False,
         )
-        self.l_greater = compute_config.dsdbsparse_type.zeros_like(self.l_lesser)
+        self.l_greater = compute_config.dsdbsparse_type.empty_like(
+            self.l_lesser, allocate=False
+        )
         # Explicitely try to free the memory for the sparsity pattern.
         del l_sparsity_pattern
-        self.l_lesser.free_data()
-        self.l_greater.free_data()
+
         # Load the Coulomb matrix.
         if quatrex_config.device.construct_from_unit_cell:
 
@@ -198,6 +200,7 @@ class CoulombScreeningSolver(SubsystemSolver):
                 block_start=start_block,
                 block_end=end_block,
                 return_sparse=True,
+                format="csr",
             )
             coulomb_matrix_sparray = coulomb_matrix_sparray.astype(xp.complex128)
             coulomb_matrix_sparray.sum_duplicates()
@@ -218,13 +221,6 @@ class CoulombScreeningSolver(SubsystemSolver):
         debug_gpu_memory_usage("After freeing memory pool")
 
         self.coulomb_matrix += coulomb_matrix_sparray
-        # self.coulomb_matrix = compute_config.dsdbsparse_type.from_sparray(
-        #     coulomb_matrix_sparray,
-        #     block_sizes=self.small_block_sizes,
-        #     global_stack_shape=(comm.stack.size,),
-        #     symmetry=quatrex_config.scba.symmetric,
-        #     symmetry_op=xp.conj,
-        # )
         # Explicitely try to free the memory for the sparsity pattern.
         del coulomb_matrix_sparray
 

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -6,14 +6,20 @@ import numpy as np
 from qttools import FloatType, NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
-from qttools.datastructures.routines import bd_matmul_distr, bd_sandwich_distr
+from qttools.datastructures.routines import (
+    bd_matmul_distr,
+    bd_sandwich,
+    bd_sandwich_distr,
+)
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler, decorate_methods
 from qttools.utils.gpu_utils import (
+    create_stream,
     debug_gpu_memory_usage,
     free_mempool,
     get_host,
     synchronize_device,
+    synchronize_stream,
 )
 from qttools.utils.input_utils import create_hamiltonian, cutoff_hr
 from qttools.utils.mpi_utils import distributed_load, get_local_slice, get_section_sizes
@@ -251,6 +257,8 @@ class CoulombScreeningSolver(SubsystemSolver):
             quatrex_config.coulomb_screening.filtering_iteration_limit
         )
 
+        self._system_stream = create_stream()
+
     def _set_block_sizes(self, block_sizes: NDArray) -> None:
         """Sets the block sizes of all matrices.
 
@@ -410,6 +418,9 @@ class CoulombScreeningSolver(SubsystemSolver):
 
     def _assemble_system_matrix(self, p_retarded: DSDBSparse) -> None:
         """Assembles the system matrix."""
+        self.coulomb_matrix.to_device(
+            delete_host=False, stream=self._system_stream, sync=False
+        )
         self.system_matrix.data = 0.0
         local_blocks, _ = get_section_sizes(
             len(self.system_matrix.block_sizes), comm.block.size
@@ -417,6 +428,7 @@ class CoulombScreeningSolver(SubsystemSolver):
         start_block = sum(local_blocks[: comm.block.rank])
         end_block = start_block + local_blocks[comm.block.rank]
 
+        synchronize_stream(self._system_stream)
         bd_matmul_distr(
             self.coulomb_matrix,
             p_retarded,
@@ -530,7 +542,6 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         # Assemble the system matrix (Includes matrix multiplication).
         t_assembly_start = time.perf_counter()
-        self.coulomb_matrix.to_device()
         self._assemble_system_matrix(p_retarded)
         p_retarded.free_data()
         synchronize_device()
@@ -545,30 +556,48 @@ class CoulombScreeningSolver(SubsystemSolver):
             )
 
         t_sandwich_start = time.perf_counter()
-        local_blocks, _ = get_section_sizes(
-            len(self.coulomb_matrix.block_sizes), comm.block.size
-        )
-        start_block = sum(local_blocks[: comm.block.rank])
-        end_block = start_block + local_blocks[comm.block.rank]
-        bd_sandwich_distr(
-            self.coulomb_matrix,
-            p_lesser,
-            out=self.l_lesser,
-            start_block=start_block,
-            end_block=end_block,
-            spillover_correction=True,
-        )
-        p_lesser.free_data()
-        bd_sandwich_distr(
-            self.coulomb_matrix,
-            p_greater,
-            out=self.l_greater,
-            start_block=start_block,
-            end_block=end_block,
-            spillover_correction=True,
-        )
-        p_greater.free_data()
-        self.coulomb_matrix.to_host()
+        if comm.block.size > 1:
+            local_blocks, _ = get_section_sizes(
+                len(self.coulomb_matrix.block_sizes), comm.block.size
+            )
+            start_block = sum(local_blocks[: comm.block.rank])
+            end_block = start_block + local_blocks[comm.block.rank]
+            bd_sandwich_distr(
+                self.coulomb_matrix,
+                p_lesser,
+                out=self.l_lesser,
+                start_block=start_block,
+                end_block=end_block,
+                spillover_correction=True,
+            )
+            p_lesser.free_data()
+            bd_sandwich_distr(
+                self.coulomb_matrix,
+                p_greater,
+                out=self.l_greater,
+                start_block=start_block,
+                end_block=end_block,
+                spillover_correction=True,
+            )
+            p_greater.free_data()
+        else:
+            bd_sandwich(
+                self.coulomb_matrix,
+                p_lesser,
+                out=self.l_lesser,
+                spillover_correction=True,
+            )
+            p_lesser.free_data()
+            bd_sandwich(
+                self.coulomb_matrix,
+                p_greater,
+                out=self.l_greater,
+                spillover_correction=True,
+            )
+            p_greater.free_data()
+        synchronize_device()
+        self.coulomb_matrix.free_data()
+        # self.coulomb_matrix.to_host()
         synchronize_device()
         t_sandwich_end = time.perf_counter()
         comm.barrier()

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -10,10 +10,12 @@ from qttools.datastructures import DSDBSparse
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler, decorate_methods
 from qttools.utils.gpu_utils import (
+    create_stream,
     debug_gpu_memory_usage,
     free_mempool,
     get_host,
     synchronize_device,
+    synchronize_stream,
 )
 from qttools.utils.input_utils import create_hamiltonian, cutoff_hr
 from qttools.utils.mpi_utils import distributed_load, get_local_slice, get_section_sizes
@@ -365,6 +367,8 @@ class ElectronSolver(SubsystemSolver):
             quatrex_config.coulomb_screening.filtering_iteration_limit
         )
 
+        self._system_stream = create_stream()
+
     def update_potential(self, new_potential: NDArray) -> None:
         """Updates the potential matrix.
 
@@ -532,6 +536,9 @@ class ElectronSolver(SubsystemSolver):
             The retarded scattering self-energy.
 
         """
+        self.hamiltonian.to_device(
+            delete_host=False, stream=self._system_stream, sync=False
+        )
         self.system_matrix.data = 0.0
         self.system_matrix += self.overlap_sparray
         scale_stack(
@@ -541,9 +548,8 @@ class ElectronSolver(SubsystemSolver):
 
         self.system_matrix -= sparse.diags(self.potential, format="csr")
         _btd_subtract(self.system_matrix, sse_retarded)
-        self.hamiltonian.to_device()
+        synchronize_stream(self._system_stream)
         _btd_subtract(self.system_matrix, self.hamiltonian)
-        self.hamiltonian.to_host()
 
     def _filter_peaks(self, out: tuple[DSDBSparse, ...]) -> None:
         """Filters out peaks in the Green's functions.
@@ -634,7 +640,11 @@ class ElectronSolver(SubsystemSolver):
 
         t_assemble_start = time.perf_counter()
         self.system_matrix.allocate_data()
-
+        sse_lesser.to_host(delete_device=False, stream=self._system_stream, sync=False)
+        sse_greater.to_host(delete_device=False, stream=self._system_stream, sync=False)
+        sse_retarded.to_host(
+            delete_device=False, stream=self._system_stream, sync=False
+        )
         self._assemble_system_matrix(sse_retarded)
         synchronize_device()
         t_assemble_end = time.perf_counter()
@@ -664,6 +674,7 @@ class ElectronSolver(SubsystemSolver):
             self._update_fermi_levels(left_band_edges, right_band_edges)
 
             synchronize_device()
+            self.hamiltonian.free_data()
             t_band_edges_end = time.perf_counter()
             comm.barrier()
             t_band_edges_end_all = time.perf_counter()

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -3,12 +3,18 @@
 import time
 
 import numpy as np
+from mpi4py.MPI import COMM_WORLD as global_comm
 from qttools import NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler, decorate_methods
-from qttools.utils.gpu_utils import get_host, synchronize_device
+from qttools.utils.gpu_utils import (
+    debug_gpu_memory_usage,
+    free_mempool,
+    get_host,
+    synchronize_device,
+)
 from qttools.utils.input_utils import create_hamiltonian, cutoff_hr
 from qttools.utils.mpi_utils import distributed_load, get_local_slice, get_section_sizes
 from qttools.utils.stack_utils import scale_stack
@@ -84,6 +90,8 @@ class ElectronSolver(SubsystemSolver):
 
         self.local_energies = get_local_slice(energies, comm.stack)
 
+        debug_gpu_memory_usage("Before constructing hamiltonian sparsity pattern")
+
         # Load the device Hamiltonian.
         synchronize_device()
         comm.barrier()
@@ -92,6 +100,8 @@ class ElectronSolver(SubsystemSolver):
             hamiltonian_unit_cells = distributed_load(
                 quatrex_config.input_dir / "hamiltonian_unit_cells.npy"
             ).astype(xp.complex128)
+
+            debug_gpu_memory_usage("After loading hamiltonian unit cells")
 
             # Determine the local slice of the data.
             # NOTE: This is arrow-wise partitioning.
@@ -115,8 +125,19 @@ class ElectronSolver(SubsystemSolver):
                 block_end=end_block,
                 return_sparse=True,
             )
+            debug_gpu_memory_usage(
+                "After creating initial hamiltonian sparsity pattern"
+            )
             hamiltonian_sparray = hamiltonian_sparray.astype(xp.complex128)
+            free_mempool()
+            debug_gpu_memory_usage(
+                "After converting hamiltonian sparsity pattern to complex128"
+            )
             hamiltonian_sparray.sum_duplicates()
+            free_mempool()
+            debug_gpu_memory_usage(
+                "After summing duplicates in hamiltonian sparsity pattern"
+            )
             block_sizes = get_host(block_sizes)
             self.block_sizes = np.asarray(
                 [block_sizes[0]] * quatrex_config.device.number_of_supercells
@@ -130,9 +151,46 @@ class ElectronSolver(SubsystemSolver):
                 distributed_load(quatrex_config.input_dir / "block_sizes.npy")
             )
 
+        debug_gpu_memory_usage("After constructing hamiltonian sparsity pattern")
+        if global_comm.rank == 0:
+            print(
+                f"    Hamiltonian sparsity pattern shape: {hamiltonian_sparray.shape}",
+                flush=True,
+            )
+            print(f"    Hamiltonian nnz: {hamiltonian_sparray.nnz}", flush=True)
+            print(f"    Hamiltonian dtype: {hamiltonian_sparray.dtype}", flush=True)
+            print(
+                f"    Hamiltonian rows dtype: {hamiltonian_sparray.row.dtype}",
+                flush=True,
+            )
+            print(
+                f"    Hamiltonian cols dtype: {hamiltonian_sparray.col.dtype}",
+                flush=True,
+            )
+            print(f"    Block sizes: {self.block_sizes}", flush=True)
+
+        self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
+            hamiltonian_sparray.astype(xp.complex128),
+            block_sizes=self.block_sizes,
+            global_stack_shape=(comm.stack.size,),
+            symmetry=quatrex_config.scba.symmetric,
+            symmetry_op=xp.conj,
+        )
+        self.hamiltonian.to_host()
+
+        debug_gpu_memory_usage("After creating Hamiltonian DSDBSparse")
+
         # Make sure that the the system matrix sparsity is a superset of
         # self-energy and Hamiltonian sparsity.
         sparsity_pattern += hamiltonian_sparray
+        del hamiltonian_sparray
+        free_mempool()
+        sparsity_pattern.sum_duplicates()
+        sparsity_pattern = sparsity_pattern.astype(xp.complex128)
+        sparsity_pattern = sparsity_pattern.tocoo()
+        free_mempool()
+
+        debug_gpu_memory_usage("After constructing system matrix sparsity pattern")
 
         synchronize_device()
         t_ham_load_end = time.perf_counter()
@@ -148,14 +206,18 @@ class ElectronSolver(SubsystemSolver):
                 flush=True,
             )
 
-        self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
-            hamiltonian_sparray.astype(xp.complex128),
-            block_sizes=self.block_sizes,
-            global_stack_shape=(comm.stack.size,),
-            symmetry=quatrex_config.scba.symmetric,
-            symmetry_op=xp.conj,
-        )
-        del hamiltonian_sparray
+        # self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
+        #     hamiltonian_sparray.astype(xp.complex128),
+        #     block_sizes=self.block_sizes,
+        #     global_stack_shape=(comm.stack.size,),
+        #     symmetry=quatrex_config.scba.symmetric,
+        #     symmetry_op=xp.conj,
+        # )
+        # del hamiltonian_sparray
+        # free_mempool()
+        # self.hamiltonian.to_host()
+
+        # debug_gpu_memory_usage("After creating Hamiltonian DSDBSparse")
 
         synchronize_device()
         t_ham_create_end = time.perf_counter()
@@ -173,12 +235,16 @@ class ElectronSolver(SubsystemSolver):
 
         # Allocate memory for the system matrix.
         self.system_matrix = compute_config.dsdbsparse_type.from_sparray(
-            sparsity_pattern.astype(xp.complex128),
+            # sparsity_pattern.astype(xp.complex128),
+            sparsity_pattern,
             block_sizes=self.block_sizes,
             global_stack_shape=self.energies.shape,
         )
         self.system_matrix.free_data()  # Free any previously allocated data
         del sparsity_pattern
+        free_mempool()
+
+        debug_gpu_memory_usage("After creating system matrix DSDBSparse")
 
         self.block_offsets = np.hstack(([0], np.cumsum(self.block_sizes)))
         # Check that the provided block sizes match the Hamiltonian.
@@ -488,7 +554,9 @@ class ElectronSolver(SubsystemSolver):
 
         self.system_matrix -= sparse.diags(self.potential, format="csr")
         _btd_subtract(self.system_matrix, sse_retarded)
+        self.hamiltonian.to_device()
         _btd_subtract(self.system_matrix, self.hamiltonian)
+        self.hamiltonian.to_host()
 
     def _filter_peaks(self, out: tuple[DSDBSparse, ...]) -> None:
         """Filters out peaks in the Green's functions.

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -169,29 +169,6 @@ class ElectronSolver(SubsystemSolver):
             )
             print(f"    Block sizes: {self.block_sizes}", flush=True)
 
-        self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
-            hamiltonian_sparray.astype(xp.complex128),
-            block_sizes=self.block_sizes,
-            global_stack_shape=(comm.stack.size,),
-            symmetry=quatrex_config.scba.symmetric,
-            symmetry_op=xp.conj,
-        )
-        self.hamiltonian.to_host()
-
-        debug_gpu_memory_usage("After creating Hamiltonian DSDBSparse")
-
-        # Make sure that the the system matrix sparsity is a superset of
-        # self-energy and Hamiltonian sparsity.
-        sparsity_pattern += hamiltonian_sparray
-        del hamiltonian_sparray
-        free_mempool()
-        sparsity_pattern.sum_duplicates()
-        sparsity_pattern = sparsity_pattern.astype(xp.complex128)
-        sparsity_pattern = sparsity_pattern.tocoo()
-        free_mempool()
-
-        debug_gpu_memory_usage("After constructing system matrix sparsity pattern")
-
         synchronize_device()
         t_ham_load_end = time.perf_counter()
         comm.barrier()
@@ -206,18 +183,16 @@ class ElectronSolver(SubsystemSolver):
                 flush=True,
             )
 
-        # self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
-        #     hamiltonian_sparray.astype(xp.complex128),
-        #     block_sizes=self.block_sizes,
-        #     global_stack_shape=(comm.stack.size,),
-        #     symmetry=quatrex_config.scba.symmetric,
-        #     symmetry_op=xp.conj,
-        # )
-        # del hamiltonian_sparray
-        # free_mempool()
-        # self.hamiltonian.to_host()
+        self.hamiltonian = compute_config.dsdbsparse_type.from_sparray(
+            hamiltonian_sparray.astype(xp.complex128),
+            block_sizes=self.block_sizes,
+            global_stack_shape=(comm.stack.size,),
+            symmetry=quatrex_config.scba.symmetric,
+            symmetry_op=xp.conj,
+        )
+        self.hamiltonian.to_host()
 
-        # debug_gpu_memory_usage("After creating Hamiltonian DSDBSparse")
+        debug_gpu_memory_usage("After creating Hamiltonian DSDBSparse")
 
         synchronize_device()
         t_ham_create_end = time.perf_counter()
@@ -233,14 +208,26 @@ class ElectronSolver(SubsystemSolver):
                 flush=True,
             )
 
+        # Make sure that the the system matrix sparsity is a superset of
+        # self-energy and Hamiltonian sparsity.
+        sparsity_pattern += hamiltonian_sparray
+        del hamiltonian_sparray
+        free_mempool()
+        sparsity_pattern.sum_duplicates()
+        sparsity_pattern = sparsity_pattern.astype(xp.complex128)
+        sparsity_pattern = sparsity_pattern.tocoo()
+        free_mempool()
+
+        debug_gpu_memory_usage("After constructing system matrix sparsity pattern")
+
         # Allocate memory for the system matrix.
         self.system_matrix = compute_config.dsdbsparse_type.from_sparray(
             # sparsity_pattern.astype(xp.complex128),
             sparsity_pattern,
             block_sizes=self.block_sizes,
             global_stack_shape=self.energies.shape,
+            allocate=False,
         )
-        self.system_matrix.free_data()  # Free any previously allocated data
         del sparsity_pattern
         free_mempool()
 

--- a/src/quatrex/electron/sse_fock.py
+++ b/src/quatrex/electron/sse_fock.py
@@ -7,7 +7,7 @@ from qttools import NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
 from qttools.profiling import Profiler
-from qttools.utils.gpu_utils import get_host, synchronize_device
+from qttools.utils.gpu_utils import free_mempool, get_host, synchronize_device
 from qttools.utils.input_utils import create_hamiltonian, cutoff_hr
 from qttools.utils.mpi_utils import distributed_load, get_section_sizes
 
@@ -65,6 +65,7 @@ class SigmaFock(ScatteringSelfEnergy):
                 block_start=start_block,
                 block_end=end_block,
                 return_sparse=True,
+                format="csr",
             )
             coulomb_matrix_sparray = coulomb_matrix_sparray.astype(xp.complex128)
             coulomb_matrix_sparray.sum_duplicates()
@@ -104,6 +105,8 @@ class SigmaFock(ScatteringSelfEnergy):
         self.coulomb_matrix_data = (
             coulomb_matrix.data[0] / quatrex_config.coulomb_screening.epsilon_r
         )
+        del coulomb_matrix
+        free_mempool()
 
     @profiler.profile(level="api")
     def compute(self, g_lesser: DSDBSparse, out: tuple[DSDBSparse, ...]) -> None:

--- a/tests/qttools/utils/test_input_utils.py
+++ b/tests/qttools/utils/test_input_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from qttools import NDArray, _DType, xp
+from qttools import FloatType, NDArray, xp
 from qttools.utils.input_utils import (
     create_coordinate_grid,
     create_hamiltonian,
@@ -25,7 +25,7 @@ R_ref = xp.loadtxt(Path(__file__).parent / "data" / "R_ref.txt", dtype=int)
         (True, xp.complex128, True),
     ],
 )
-def test_read_hr_dat(return_all: bool, dtype: _DType, read_fast: bool):
+def test_read_hr_dat(return_all: bool, dtype: xp.dtype[FloatType], read_fast: bool):
     if return_all:
         hr, R = read_hr_dat(wannier90_hr_path, return_all, dtype, read_fast)
     else:


### PR DESCRIPTION
**PR by [alexnick83](https://github.com/alexnick83)**
_Originally opened at 2025-06-25T13:14:34Z GMT_
_Originally opened as [https://github.com/vincent-maillou/qttools/pull/158](https://github.com/vincent-maillou/qttools/pull/158)_

This PR was originally in qttools repository (branch: mem-use-opt).

Original PR description:
Reduces unnecessary data copies when creating DSDBSparse arrays and introduces new utility methods.

This PR introduces a few memory use optimizations:
- [x] Uses new DSDBSparse API methods to defer data allocation or avoid extraneous data copies when generating from a sparse array.
- [x] More aggressively allocates and deallocates data during the SCBA loop.
- [x] Copies some data to the host when they are not needed and copies them back to the device when they are required again.


----