### PR TITLE
Apply specific nvmath changes

### DIFF
--- a/src/qttools/kernels/linalg/eig.py
+++ b/src/qttools/kernels/linalg/eig.py
@@ -2,7 +2,9 @@
 
 import numba as nb
 import numpy as np
+import nvmath
 from numba.typed import List
+from nvmath.bindings import cusolverDn
 
 from qttools import NDArray, xp
 from qttools.profiling import Profiler
@@ -108,7 +110,9 @@ def _eig_cupy(
         The eigenvectors.
 
     """
-    if isinstance(A, list):
+    if isinstance(
+        A, list
+    ):  # comment: soon there will be batched geev, so pls replace for loop then.
         w = []
         v = []
         for a in A:
@@ -119,6 +123,124 @@ def _eig_cupy(
         w, v = xp.linalg.eig(A)
 
     return w, v
+
+
+@profiler.profile(level="debug")
+def _eig_nvmath(
+    A: NDArray | List[NDArray],
+) -> tuple[NDArray, NDArray] | tuple[List[NDArray], List[NDArray]]:
+    """Computes the eigenvalues and eigenvectors of multiple matrices.
+
+    Parameters
+    ----------
+    A : NDArray | List[NDArray]
+        The matrices.
+
+    Returns
+    -------
+    NDArray | List[NDArray]
+        The eigenvalues.
+    NDArray | List[NDArray]
+        The eigenvectors.
+
+    """
+    if isinstance(A, list):
+        w = []
+        v = []
+        for a in A:
+            w_, v_ = _eig_nvmath_kernel(a)
+            w.append(w_)
+            v.append(v_)
+    else:
+        # Loading in a batch of matrices:
+        batch_size = A.shape[0]
+        w = xp.zeros((batch_size, A.shape[1]), dtype=xp.complex128)
+        v = xp.zeros((batch_size, A.shape[1], A.shape[1]), dtype=xp.complex128)
+        for i in range(batch_size):
+            w[i, :], v[i, :, :] = _eig_nvmath_kernel(A[i, :, :])
+        # w, v = _eig_nvmath_kernel(A[0, :, :])
+    return w, v
+
+
+@profiler.profile(level="debug")
+def _eig_nvmath_kernel(
+    A: NDArray,
+) -> tuple[NDArray, NDArray]:
+    # Initialize cuSolver handle
+    handle = cusolverDn.create()
+    params = cusolverDn.create_params()
+
+    n = A.shape[0]
+    n_64 = np.int64(n)
+    lda = n_64
+    ldvl = n_64
+    ldvr = n_64
+
+    # Prepare input matrix (copy since xgeev modifies it) We need column major format here!
+    # Comment: I assume xp is cupy here, please check how you want to handle this
+    A_work = xp.asfortranarray(xp.copy(A))
+
+    # Allocate output arrays
+    w_complex = xp.zeros(n, dtype=xp.complex128)
+    vl = xp.zeros(
+        (n, n), dtype=xp.complex128, order="F"
+    )  # Left eigenvectors (not computed)
+    vr = xp.zeros((n, n), dtype=xp.complex128, order="F")  # Right eigenvectors
+    info = xp.zeros(1, dtype=xp.int64)
+
+    yes_vector = nvmath.bindings.cusolver.EigMode.VECTOR
+    no_vector = nvmath.bindings.cusolver.EigMode.NOVECTOR
+
+    # Query workspace size
+    lwork_device, lwork_host = cusolverDn.xgeev_buffer_size(
+        handle,
+        params,
+        no_vector,  # jobvl: don't compute left eigenvectors
+        yes_vector,  # jobvr: compute right eigenvectors
+        n_64,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
+        A_work.data.ptr,
+        lda,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
+        w_complex.data.ptr,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
+        vl.data.ptr,
+        ldvl,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
+        vr.data.ptr,
+        ldvr,
+        nvmath.CudaDataType.CUDA_C_64F,  # compute_type
+    )
+
+    workspace_device = xp.cuda.alloc(lwork_device)
+    workspace_host = np.empty(lwork_host, dtype=xp.int8)
+    # Compute eigenvalues and eigenvectors
+    cusolverDn.xgeev(
+        handle,
+        params,
+        no_vector,  # jobvl: don't compute left eigenvectors
+        yes_vector,  # jobvr: compute right eigenvectors
+        n_64,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
+        A_work.data.ptr,
+        lda,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
+        w_complex.data.ptr,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
+        vl.data.ptr,
+        ldvl,
+        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
+        vr.data.ptr,
+        ldvr,
+        nvmath.CudaDataType.CUDA_C_64F,  # compute_type
+        workspace_device.ptr,
+        lwork_device,
+        workspace_host.ctypes.data,
+        lwork_host,
+        info.data.ptr,
+    )
+
+    return w_complex, xp.ascontiguousarray(vr)
 
 
 @profiler.profile(level="api")
@@ -145,6 +267,7 @@ def eig(
         The matrices.
     compute_module : str, optional
         The location where to compute the eigenvalues and eigenvectors.
+        Can be either "numpy" or "cupy". The default is "numpy".
         Can be either "numpy" or "cupy". The default is "numpy".
     output_module : str, optional
         The location where to store the eigenvalues and eigenvectors.
@@ -174,8 +297,9 @@ def eig(
     if output_module is None:
         output_module = input_module
 
-    if compute_module == "cupy" and hasattr(xp.linalg, "eig") is False:
-        raise ValueError("Eig is not available in cupy.")
+    # see comment below (of course nvmath doesn't call it "eig")
+    # if compute_module == "cupy" and hasattr(xp.linalg, "eig") is False:
+    #     raise ValueError("Eig is not available in cupy.")
 
     if xp.__name__ == "numpy" and (
         compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
@@ -191,7 +315,12 @@ def eig(
         A = get_any_location(A, compute_module, use_pinned_memory=use_pinned_memory)
 
     if compute_module == "cupy":
-        w, v = _eig_cupy(A)
+        """comment: You seem to use "cupy" to mean "in GPU memory" when calling get_any_location,
+        and to use the cupy module when running eig so
+          i let you decide how you want to handle this situation.
+        """
+        # w, v = _eig_cupy(A)
+        w, v = _eig_nvmath(A)
     elif compute_module == "numpy":
         w, v = _eig_numpy(A)
 

--- a/src/qttools/kernels/linalg/eig.py
+++ b/src/qttools/kernels/linalg/eig.py
@@ -2,15 +2,27 @@
 
 import numba as nb
 import numpy as np
-import nvmath
 from numba.typed import List
-from nvmath.bindings import cusolverDn
+
+try:
+    import nvmath
+    from nvmath.bindings import cusolverDn
+
+    nvmath_available = True
+except ImportError:
+    nvmath_available = False
 
 from qttools import NDArray, xp
 from qttools.profiling import Profiler
 from qttools.utils.gpu_utils import get_any_location, get_array_module_name
 
 profiler = Profiler()
+
+library_to_location = {
+    "numpy": "numpy",
+    "cupy": "cupy",
+    "nvmath": "cupy",
+}
 
 
 @profiler.profile(level="debug")
@@ -145,20 +157,32 @@ def _eig_nvmath(
 
     """
     if isinstance(A, list):
+        in_dtype = A[0].dtype
+    else:
+        in_dtype = A.dtype
+
+    # real matrices have complex eigenvalues/vectors in general
+    out_dtype = xp.complex128 if in_dtype == xp.float64 else xp.complex64
+
+    if in_dtype != xp.complex128:
+        raise ValueError("nvmath implementation only supports complex128 matrices.")
+
+    if isinstance(A, list):
         w = []
         v = []
         for a in A:
             w_, v_ = _eig_nvmath_kernel(a)
             w.append(w_)
             v.append(v_)
+    elif A.ndim == 2:
+        w, v = _eig_nvmath_kernel(A)
     else:
-        # Loading in a batch of matrices:
         batch_size = A.shape[0]
-        w = xp.zeros((batch_size, A.shape[1]), dtype=xp.complex128)
-        v = xp.zeros((batch_size, A.shape[1], A.shape[1]), dtype=xp.complex128)
+        w = xp.zeros((batch_size, A.shape[1]), dtype=out_dtype)
+        v = xp.zeros((batch_size, A.shape[1], A.shape[1]), dtype=out_dtype)
         for i in range(batch_size):
             w[i, :], v[i, :, :] = _eig_nvmath_kernel(A[i, :, :])
-        # w, v = _eig_nvmath_kernel(A[0, :, :])
+
     return w, v
 
 
@@ -166,7 +190,11 @@ def _eig_nvmath(
 def _eig_nvmath_kernel(
     A: NDArray,
 ) -> tuple[NDArray, NDArray]:
-    # Initialize cuSolver handle
+
+    # TODO: this will not work for real A
+    # and the cupy binding should be followed
+
+    # TODO: not recommended to create/destroy handle every time
     handle = cusolverDn.create()
     params = cusolverDn.create_params()
 
@@ -177,68 +205,70 @@ def _eig_nvmath_kernel(
     ldvr = n_64
 
     # Prepare input matrix (copy since xgeev modifies it) We need column major format here!
-    # Comment: I assume xp is cupy here, please check how you want to handle this
     A_work = xp.asfortranarray(xp.copy(A))
 
     # Allocate output arrays
     w_complex = xp.zeros(n, dtype=xp.complex128)
-    vl = xp.zeros(
-        (n, n), dtype=xp.complex128, order="F"
-    )  # Left eigenvectors (not computed)
-    vr = xp.zeros((n, n), dtype=xp.complex128, order="F")  # Right eigenvectors
+    vl = xp.zeros((n, n), dtype=xp.complex128, order="F")
+    # Left eigenvectors (not computed)
+    vr = xp.zeros((n, n), dtype=xp.complex128, order="F")
     info = xp.zeros(1, dtype=xp.int64)
 
     yes_vector = nvmath.bindings.cusolver.EigMode.VECTOR
     no_vector = nvmath.bindings.cusolver.EigMode.NOVECTOR
 
-    # Query workspace size
-    lwork_device, lwork_host = cusolverDn.xgeev_buffer_size(
-        handle,
-        params,
-        no_vector,  # jobvl: don't compute left eigenvectors
-        yes_vector,  # jobvr: compute right eigenvectors
-        n_64,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
-        A_work.data.ptr,
-        lda,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
-        w_complex.data.ptr,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
-        vl.data.ptr,
-        ldvl,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
-        vr.data.ptr,
-        ldvr,
-        nvmath.CudaDataType.CUDA_C_64F,  # compute_type
-    )
+    try:
+        # Query workspace size
+        lwork_device, lwork_host = cusolverDn.xgeev_buffer_size(
+            handle,
+            params,
+            no_vector,  # jobvl: don't compute left eigenvectors
+            yes_vector,  # jobvr: compute right eigenvectors
+            n_64,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
+            A_work.data.ptr,
+            lda,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
+            w_complex.data.ptr,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
+            vl.data.ptr,
+            ldvl,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
+            vr.data.ptr,
+            ldvr,
+            nvmath.CudaDataType.CUDA_C_64F,  # compute_type
+        )
 
-    workspace_device = xp.cuda.alloc(lwork_device)
-    workspace_host = np.empty(lwork_host, dtype=xp.int8)
-    # Compute eigenvalues and eigenvectors
-    cusolverDn.xgeev(
-        handle,
-        params,
-        no_vector,  # jobvl: don't compute left eigenvectors
-        yes_vector,  # jobvr: compute right eigenvectors
-        n_64,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
-        A_work.data.ptr,
-        lda,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
-        w_complex.data.ptr,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
-        vl.data.ptr,
-        ldvl,
-        nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
-        vr.data.ptr,
-        ldvr,
-        nvmath.CudaDataType.CUDA_C_64F,  # compute_type
-        workspace_device.ptr,
-        lwork_device,
-        workspace_host.ctypes.data,
-        lwork_host,
-        info.data.ptr,
-    )
+        workspace_device = xp.cuda.alloc(lwork_device)
+        workspace_host = np.empty(lwork_host, dtype=xp.int8)
+        # Compute eigenvalues and eigenvectors
+        cusolverDn.xgeev(
+            handle,
+            params,
+            no_vector,  # jobvl: don't compute left eigenvectors
+            yes_vector,  # jobvr: compute right eigenvectors
+            n_64,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_a
+            A_work.data.ptr,
+            lda,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_w
+            w_complex.data.ptr,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_vl
+            vl.data.ptr,
+            ldvl,
+            nvmath.CudaDataType.CUDA_C_64F,  # data_type_vr
+            vr.data.ptr,
+            ldvr,
+            nvmath.CudaDataType.CUDA_C_64F,  # compute_type
+            workspace_device.ptr,
+            lwork_device,
+            workspace_host.ctypes.data,
+            lwork_host,
+            info.data.ptr,
+        )
+    finally:
+        cusolverDn.destroy_params(params)
+        cusolverDn.destroy(handle)
 
     return w_complex, xp.ascontiguousarray(vr)
 
@@ -267,8 +297,7 @@ def eig(
         The matrices.
     compute_module : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "numpy" or "cupy". The default is "numpy".
-        Can be either "numpy" or "cupy". The default is "numpy".
+        Can be either "numpy" or "cupy" or "nvmath". The default is "numpy".
     output_module : str, optional
         The location where to store the eigenvalues and eigenvectors.
         Can be either "numpy"
@@ -297,32 +326,43 @@ def eig(
     if output_module is None:
         output_module = input_module
 
-    # see comment below (of course nvmath doesn't call it "eig")
-    # if compute_module == "cupy" and hasattr(xp.linalg, "eig") is False:
-    #     raise ValueError("Eig is not available in cupy.")
+    if compute_module == "cupy" and hasattr(xp.linalg, "eig") is False:
+        raise ValueError("Eig is not available in cupy.")
+
+    if compute_module == "nvmath" and nvmath_available is False:
+        raise ValueError("nvmath is not available.")
 
     if xp.__name__ == "numpy" and (
-        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+        compute_module in ["cupy", "nvmath"]
+        or output_module in ["cupy", "nvmath"]
+        or input_module in ["cupy", "nvmath"]
     ):
         raise ValueError("Cannot do gpu computation with numpy as xp.")
 
     if isinstance(A, (List, list)):
         A = [
-            get_any_location(a, compute_module, use_pinned_memory=use_pinned_memory)
+            get_any_location(
+                a,
+                library_to_location[compute_module],
+                use_pinned_memory=use_pinned_memory,
+            )
             for a in A
         ]
     else:
-        A = get_any_location(A, compute_module, use_pinned_memory=use_pinned_memory)
+        A = get_any_location(
+            A, library_to_location[compute_module], use_pinned_memory=use_pinned_memory
+        )
 
     if compute_module == "cupy":
-        """comment: You seem to use "cupy" to mean "in GPU memory" when calling get_any_location,
-        and to use the cupy module when running eig so
-          i let you decide how you want to handle this situation.
-        """
-        # w, v = _eig_cupy(A)
+        w, v = _eig_cupy(A)
+    elif compute_module == "nvmath":
         w, v = _eig_nvmath(A)
     elif compute_module == "numpy":
         w, v = _eig_numpy(A)
+    else:
+        raise ValueError(
+            'compute_module must be either "numpy", "cupy" or "nvmath".',
+        )
 
     if isinstance(w, (List, list)):
         return (

--- a/src/qttools/lyapunov/spectral.py
+++ b/src/qttools/lyapunov/spectral.py
@@ -22,7 +22,7 @@ class Spectral(LyapunovSolver):
         The threshold for the relative recursion error to issue a warning.
     eig_compute_location : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "numpy" or "cupy". Only relevant if cupy is used.
+        Can be either "numpy" or "cupy" or "nvmath".
     reduce_sparsity : bool, optional
         Whether to reduce the sparsity of the system matrix.
     use_pinned_memory : bool, optional

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -48,12 +48,11 @@ class Beyn(NEVP):
         Only relevant for GPU computations.
     eig_compute_location : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "numpy" or "cupy". Only relevant if cupy is used.
+        Can be either "numpy" or "cupy" or "nvmath".
     project_compute_location : str, optional
         The location where to compute the singular value
         or qr decomposition for the projector.
-        Can be either "numpy" or "cupy". Only relevant if cupy is
-        used.
+        Can be either "numpy" or "cupy".
     use_qr : bool, optional
         Whether to use QR decomposition for the projector instead of SVD.
         Default is `False`.

--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -28,8 +28,7 @@ class Full(NEVP):
     ----------
     eig_compute_location : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "numpy" or "cupy". Only relevant if cupy is used.
-        The default is "numpy".
+        Can be either "numpy" or "cupy" or "nvmath".
     use_pinned_memory : bool, optional
         Whether to use pinnend memory if cupy is used.
         Default is `True`.

--- a/src/quatrex/core/compute_config.py
+++ b/src/quatrex/core/compute_config.py
@@ -25,7 +25,7 @@ class LyapunovConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    eig_compute_location: Literal["numpy", "cupy"] = "numpy"
+    eig_compute_location: Literal["numpy", "cupy", "nvmath"] = "numpy"
     use_pinned_memory: bool = True
 
 
@@ -34,7 +34,7 @@ class NEVPConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    eig_compute_location: Literal["numpy", "cupy"] = "numpy"
+    eig_compute_location: Literal["numpy", "cupy", "nvmath"] = "numpy"
 
     # Parameters for contour NEVP solvers.
     project_compute_location: Literal["numpy", "cupy"] = "numpy"

--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -178,8 +178,6 @@ class ElectronConfig(BaseModel):
     eta_obc: NonNegativeFloat = 0  # eV
     eta: NonNegativeFloat = 1e-12  # eV
 
-    obc_batch_size: PositiveInt = 1
-
     fermi_level: float | None = None
     conduction_band_edge: float | None = None
     valence_band_edge: float | None = None

--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -178,6 +178,8 @@ class ElectronConfig(BaseModel):
     eta_obc: NonNegativeFloat = 0  # eV
     eta: NonNegativeFloat = 1e-12  # eV
 
+    obc_batch_size: PositiveInt = 1
+
     fermi_level: float | None = None
     conduction_band_edge: float | None = None
     valence_band_edge: float | None = None

--- a/tests/qttools/kernels/conftest.py
+++ b/tests/qttools/kernels/conftest.py
@@ -67,6 +67,12 @@ COMPUTE_MODULE = [
     pytest.param("cupy", id="cupy"),
 ]
 
+EIG_COMPUTE_MODULE = [
+    pytest.param("numpy", id="numpy"),
+    pytest.param("cupy", id="cupy"),
+    pytest.param("nvmath", id="nvmath"),
+]
+
 OUTPUT_MODULE = [
     pytest.param("numpy", id="numpy"),
     pytest.param("cupy", id="cupy"),
@@ -150,6 +156,11 @@ def full_matrices(request: pytest.FixtureRequest):
 
 @pytest.fixture(params=COMPUTE_MODULE)
 def compute_module(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=EIG_COMPUTE_MODULE)
+def eig_compute_module(request: pytest.FixtureRequest):
     return request.param
 
 

--- a/tests/qttools/kernels/linalg/test_eig.py
+++ b/tests/qttools/kernels/linalg/test_eig.py
@@ -62,12 +62,12 @@ def test_eig_numba_list(n: int, batch_shape: tuple[int, ...]):
 
 
 @pytest.mark.usefixtures(
-    "n", "compute_module", "input_module", "output_module", "use_pinned_memory"
+    "n", "eig_compute_module", "input_module", "output_module", "use_pinned_memory"
 )
 @pytest.mark.parametrize("if_list", [False, True])
 def test_eig(
     n: int,
-    compute_module: str,
+    eig_compute_module: str,
     input_module: str,
     output_module: str,
     if_list: bool,
@@ -76,11 +76,19 @@ def test_eig(
     """Tests the eig function."""
 
     if xp.__name__ == "numpy" and (
-        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+        eig_compute_module in ["cupy", "nvmath"]
+        or output_module in ["cupy"]
+        or input_module in ["cupy"]
     ):
         return
-    if compute_module == "cupy" and (hasattr(xp.linalg, "eig") is False):
+    if eig_compute_module == "cupy" and (hasattr(xp.linalg, "eig") is False):
         return
+
+    if eig_compute_module == "nvmath":
+        try:
+            import nvmath  # noqa: F401  # type: ignore
+        except ImportError:
+            return
 
     if input_module == "cupy":
         rng = cp.random.default_rng()
@@ -94,7 +102,7 @@ def test_eig(
 
     w, v = linalg.eig(
         A,
-        compute_module=compute_module,
+        compute_module=eig_compute_module,
         output_module=output_module,
         use_pinned_memory=use_pinned_memory,
     )


### PR DESCRIPTION
Pull request that would allow the use of the nvmath binding for xgeev for the full NEVP boundary solver.
Reason for this change is that it wasn't possible for me to create a consistent environment that installs cupy from source (requires CDK 13) and does a conda install of nvmath (requires CDK<13 to install libcudss directly).

I left the eig_compute_location as cupy because you use this variable to sometimes mean to target GPU memory and sometimes to refer to the cupy module so the call to _eig_nvmath looks a bit unclean. I let you decide how you want to handle it. Müsst Ihr wissen.