### PR TITLE
Change treat_pairwise default value to False

### DIFF
--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -110,7 +110,7 @@ class OBCConfig(BaseModel):
     num_ref_iterations: PositiveInt = Field(default=2, ge=1)
     x_ii_formula: Literal["self-energy", "direct"] = "self-energy"
     two_sided: bool = False
-    treat_pairwise: bool = True
+    treat_pairwise: bool = False
     pairing_threshold: PositiveFloat = 0.25
     min_propagation: PositiveFloat = 1e-2
     residual_tolerance: PositiveFloat = 1e-3


### PR DESCRIPTION
This pull request makes a small configuration change to the `OBCConfig` class in `src/quatrex/core/quatrex_config.py`. The default value for the `treat_pairwise` option has been changed from `True` to `False`.

`treat_pairwise` makes the OBC calculation very unstable for some devices (metal contacts, large nanowires).