### PR TITLE
Change inv kernel calls

### DIFF
--- a/src/qttools/greens_function_solver/inv.py
+++ b/src/qttools/greens_function_solver/inv.py
@@ -3,7 +3,7 @@
 from qttools import xp
 from qttools.datastructures.dsdbsparse import DSDBSparse
 from qttools.greens_function_solver.solver import GFSolver, OBCBlocks
-from qttools.kernels.linalg import inv
+from qttools.kernels import linalg
 from qttools.profiling import Profiler, decorate_methods
 from qttools.utils.solvers_utils import get_batches
 
@@ -91,7 +91,7 @@ class Inv(GFSolver):
                 b_ = slice(a.block_offsets[j], a.block_offsets[j + 1], 1)
                 a_dense[:, b_, b_] -= block[stack_slice]
 
-            inv_a[: batches_sizes[i]] = inv(a_dense)
+            inv_a[: batches_sizes[i]] = linalg.inv(a_dense)
 
             out.data[stack_slice] = inv_a[: batches_sizes[i], ..., rows, cols]
 
@@ -205,7 +205,7 @@ class Inv(GFSolver):
                 if block_g is not None:
                     sigma_greater_dense[:, b_, b_] -= block_g[stack_slice]
 
-            x_r[: batches_sizes[i]] = inv(a_dense)
+            x_r[: batches_sizes[i]] = linalg.inv(a_dense)
             x_l[: batches_sizes[i]] = (
                 x_r[: batches_sizes[i]]
                 @ sigma_lesser_dense

--- a/src/qttools/greens_function_solver/rgf.py
+++ b/src/qttools/greens_function_solver/rgf.py
@@ -3,7 +3,7 @@
 from qttools import NDArray, xp
 from qttools.datastructures.dsdbsparse import DSDBSparse
 from qttools.greens_function_solver.solver import GFSolver, OBCBlocks
-from qttools.kernels.linalg import inv
+from qttools.kernels import linalg
 from qttools.profiling import Profiler, decorate_methods
 from qttools.utils.solvers_utils import get_batches
 
@@ -77,7 +77,7 @@ class RGF(GFSolver):
                 a_.blocks[0, 0] if obc is None else a_.blocks[0, 0] - obc[stack_slice]
             )
 
-            x_diag_blocks[0] = inv(a_00)
+            x_diag_blocks[0] = linalg.inv(a_00)
 
             # Forwards sweep.
             for i in range(a.num_blocks - 1):
@@ -91,7 +91,7 @@ class RGF(GFSolver):
                     else a_.blocks[j, j] - obc[stack_slice]
                 )
 
-                x_diag_blocks[j] = inv(
+                x_diag_blocks[j] = linalg.inv(
                     a_jj - a_.blocks[j, i] @ x_diag_blocks[i] @ a_.blocks[i, j]
                 )
 
@@ -228,7 +228,7 @@ class RGF(GFSolver):
                 else sigma_greater_.blocks[0, 0] + obc_g[stack_slice]
             )
 
-            xr_jj = inv(a_jj)
+            xr_jj = linalg.inv(a_jj)
             xr_jj_dagger = xr_jj.conj().swapaxes(-2, -1)
             xr_diag_blocks[0] = xr_jj
             xl_diag_blocks[0] = xr_jj @ sl_jj @ xr_jj_dagger
@@ -268,7 +268,7 @@ class RGF(GFSolver):
                 # Precompute some terms that are used multiple times.
                 a_ji_xr_ii = a_ji @ xr_ii
 
-                xr_jj = inv(a_jj - a_ji_xr_ii @ a_.blocks[i, j])
+                xr_jj = linalg.inv(a_jj - a_ji_xr_ii @ a_.blocks[i, j])
                 xr_jj_dagger = xr_jj.conj().swapaxes(-2, -1)
                 xr_diag_blocks[j] = xr_jj
 

--- a/src/qttools/kernels/operator.py
+++ b/src/qttools/kernels/operator.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
 
 from qttools import QTX_USE_CUPY_JIT, NDArray, xp
-from qttools.kernels.linalg.inv import inv
+from qttools.kernels import linalg
 from qttools.profiling import Profiler
 
 profiler = Profiler()
@@ -180,4 +180,4 @@ def operator_inverse(
             ),
         )
 
-    return inv(operator.astype(contour_type)).astype(in_type)
+    return linalg.inv(operator.astype(contour_type)).astype(in_type)

--- a/src/qttools/kernels/operator.py
+++ b/src/qttools/kernels/operator.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
 
 from qttools import QTX_USE_CUPY_JIT, NDArray, xp
+from qttools.kernels.linalg.inv import inv
 from qttools.profiling import Profiler
 
 profiler = Profiler()
@@ -179,4 +180,4 @@ def operator_inverse(
             ),
         )
 
-    return xp.linalg.inv(operator.astype(contour_type)).astype(in_type)
+    return inv(operator.astype(contour_type)).astype(in_type)

--- a/src/qttools/lyapunov/spectral.py
+++ b/src/qttools/lyapunov/spectral.py
@@ -81,7 +81,7 @@ class Spectral(LyapunovSolver):
             use_pinned_memory=self.use_pinned_memory,
         )
 
-        inv_vs = xp.linalg.inv(vs)
+        inv_vs = linalg.inv(vs)
         inv_vs = xp.broadcast_to(inv_vs, q.shape)
         gamma = inv_vs @ q @ inv_vs.conj().swapaxes(-1, -2)
 

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -199,7 +199,7 @@ class Beyn(NEVP):
             )
 
         if left:
-            a = xp.linalg.inv(r.conj().swapaxes(-2, -1)) @ P_1 @ q
+            a = linalg.inv(r.conj().swapaxes(-2, -1)) @ P_1 @ q
         else:
             a = q.conj().swapaxes(-2, -1) @ P_1 @ xp.linalg.inv(r)
 

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -201,7 +201,7 @@ class Beyn(NEVP):
         if left:
             a = linalg.inv(r.conj().swapaxes(-2, -1)) @ P_1 @ q
         else:
-            a = q.conj().swapaxes(-2, -1) @ P_1 @ xp.linalg.inv(r)
+            a = q.conj().swapaxes(-2, -1) @ P_1 @ linalg.inv(r)
 
         if left:
             return a, q.conj().swapaxes(-2, -1)

--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -64,7 +64,7 @@ class Full(NEVP):
 
         """
 
-        inverse = xp.linalg.inv(sum(a_xx))
+        inverse = linalg.inv(sum(a_xx))
 
         # NOTE: CuPy does not expose a `block` function.
         row = xp.concatenate(

--- a/src/qttools/obc/obc.py
+++ b/src/qttools/obc/obc.py
@@ -203,7 +203,7 @@ class OBCMemoizer:
         if x_ii is None and self.memoizing_mode in ["auto", "force-after-first"]:
             return self._call_with_cache(a_ii, a_ij, a_ji, contact, out=out)
         elif self.memoizing_mode == "force":
-            x_ii = xp.linalg.inv(a_ii) if x_ii is None else x_ii
+            x_ii = inv(a_ii) if x_ii is None else x_ii
 
         x_ii_ref = inv(a_ii - a_ji @ x_ii @ a_ij)
 

--- a/src/qttools/obc/obc.py
+++ b/src/qttools/obc/obc.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 
 from qttools import NDArray, xp
 from qttools.comm import comm
-from qttools.kernels.linalg import inv
+from qttools.kernels import linalg
 from qttools.profiling import Profiler
 
 profiler = Profiler()
@@ -203,9 +203,9 @@ class OBCMemoizer:
         if x_ii is None and self.memoizing_mode in ["auto", "force-after-first"]:
             return self._call_with_cache(a_ii, a_ij, a_ji, contact, out=out)
         elif self.memoizing_mode == "force":
-            x_ii = inv(a_ii) if x_ii is None else x_ii
+            x_ii = linalg.inv(a_ii) if x_ii is None else x_ii
 
-        x_ii_ref = inv(a_ii - a_ji @ x_ii @ a_ij)
+        x_ii_ref = linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
         if self.memoizing_mode == "auto":
 
@@ -229,9 +229,9 @@ class OBCMemoizer:
 
         # Do refinement iterations.
         for __ in range(self.num_ref_iterations - 2):
-            x_ii = inv(a_ii - a_ji @ x_ii @ a_ij)
+            x_ii = linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
-        x_ii_ref = inv(a_ii - a_ji @ x_ii @ a_ij)
+        x_ii_ref = linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
         absolute_recursion_errors = xp.linalg.norm(x_ii_ref - x_ii, axis=(-2, -1))
         relative_recursion_errors = absolute_recursion_errors / xp.linalg.norm(

--- a/src/qttools/obc/sancho_rubio.py
+++ b/src/qttools/obc/sancho_rubio.py
@@ -3,7 +3,7 @@
 import warnings
 
 from qttools import NDArray, xp
-from qttools.kernels.linalg import inv
+from qttools.kernels import linalg
 from qttools.obc.obc import OBCSolver
 from qttools.profiling import Profiler
 
@@ -71,7 +71,7 @@ class SanchoRubio(OBCSolver):
 
         delta = float("inf")
         for __ in range(self.max_iterations):
-            inverse = inv(epsilon)
+            inverse = linalg.inv(epsilon)
 
             epsilon = epsilon - alpha @ inverse @ beta - beta @ inverse @ alpha
             epsilon_s = epsilon_s - alpha @ inverse @ beta
@@ -89,7 +89,7 @@ class SanchoRubio(OBCSolver):
         else:  # Did not break, i.e. max_iterations reached.
             warnings.warn("Surface Green's function did not converge.", RuntimeWarning)
 
-        x_ii = inv(epsilon_s)
+        x_ii = linalg.inv(epsilon_s)
 
         if out is not None:
             out[...] = x_ii

--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -4,7 +4,7 @@ import warnings
 
 from qttools import NDArray, xp
 from qttools.datastructures.dsdbsparse import _block_view
-from qttools.kernels.linalg import inv
+from qttools.kernels import linalg
 from qttools.nevp import NEVP
 from qttools.obc.obc import OBCSolver
 from qttools.profiling import Profiler, decorate_methods
@@ -509,13 +509,13 @@ class Spectral(OBCSolver):
                 w = ws[i, m]
                 # Moore-Penrose pseudoinverse.
                 if self.two_sided:
-                    v_inv = inv(vl.conj().T @ vr) @ vl.conj().T
+                    v_inv = linalg.inv(vl.conj().T @ vr) @ vl.conj().T
                 else:
-                    v_inv = inv(vr.conj().T @ vr) @ vr.conj().T
+                    v_inv = linalg.inv(vr.conj().T @ vr) @ vr.conj().T
                 x_ii_a_ij[i] = vr / w @ v_inv
 
             # Calculate the surface Green's function.
-            return inv(a_ii + a_ji @ x_ii_a_ij)
+            return linalg.inv(a_ii + a_ji @ x_ii_a_ij)
 
         if self.x_ii_formula == "direct":
             # Equation (15).
@@ -524,7 +524,7 @@ class Spectral(OBCSolver):
                 vr = vrs[i][:, m]
                 w = ws[i, m]
                 # "More stable" computation of the surface Green's function.
-                inverse = inv(
+                inverse = linalg.inv(
                     vr.conj().T @ a_ii[i] @ vr + vr.conj().T @ a_ji[i] @ vr / w
                 )
                 x_ii[i] = vr @ inverse @ vr.conj().T
@@ -661,9 +661,9 @@ class Spectral(OBCSolver):
 
         # Perform a number of refinement iterations.
         for __ in range(self.num_ref_iterations - 1):
-            x_ii = inv(a_ii - a_ji @ x_ii @ a_ij)
+            x_ii = linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
-        x_ii_ref = inv(a_ii - a_ji @ x_ii @ a_ij)
+        x_ii_ref = linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
         # Check the batch average recursion error.
         recursion_error = xp.max(
@@ -691,7 +691,8 @@ class Spectral(OBCSolver):
 
             # Compute injection vector
             injection = (
-                -a_ji[0, :, :] @ vrs_inj @ inv(wrs_inj) - sigma_retarded @ vrs_inj
+                -a_ji[0, :, :] @ vrs_inj @ linalg.inv(wrs_inj)
+                - sigma_retarded @ vrs_inj
             )
 
             return x_ii_ref, sigma_retarded, injection, wrs[0, mask_injected]


### PR DESCRIPTION
Cupy inversion kernel might be slow in case of batching when a big block size is present. By switching to our custom inv kernel (`linalg.inv`), disbatching is automatically performed when needed (it calls the cupy `solve` function).