### PR TITLE
Refactor obc tests to use real example data

### DIFF
--- a/tests/qttools/obc/conftest.py
+++ b/tests/qttools/obc/conftest.py
@@ -3,21 +3,20 @@
 import pytest
 
 from qttools import NDArray, xp
-from qttools.datastructures.dsdbsparse import _block_view
 from qttools.nevp import NEVP, Beyn, Full
+from qttools.utils.gpu_utils import get_host
+from qttools.utils.mpi_utils import distributed_load
+from quatrex.cli.main import fetch_example
+from quatrex.core.compute_config import CommConfig
+from quatrex.core.quatrex_config import parse_config as parse_quatrex_config
+from quatrex.examples import get_example_dir
 
-# NOTE: The matrices we generate here generally have eigenvalues with an
-# absolute value around 130. We set the outer radius to 150 and the
-# inner radius to 0.9. The subspace dimension is chosen sufficiently
-# large to capture all the eigenvalues in that annulus. The number of
-# quadrature points is set such that non-spurious eigenvalues get
-# approximated accurately enough.
 NEVP_SOLVERS = [
     pytest.param(
-        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=False), id="Beyn"
+        Beyn(r_o=10, r_i=0.99, m_0=32, num_quad_points=15, use_qr=False), id="Beyn"
     ),
     pytest.param(
-        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=True), id="Beyn"
+        Beyn(r_o=10, r_i=0.99, m_0=32, num_quad_points=15, use_qr=True), id="Beyn"
     ),
     pytest.param(Full(), id="Full"),
 ]
@@ -40,12 +39,6 @@ BATCH_SIZE = [
 ]
 
 CONTACTS = ["left", "right"]
-
-TWO_SIDED = [True, False]
-
-TREAT_PAIRWISE = [True, False]
-
-RESIDUAL_NORMALIZATION_FORMULAS = ["operator", "eigenvalue", None]
 
 
 @pytest.fixture(params=X_II_FORMULAS)
@@ -78,45 +71,54 @@ def batch_size(request: pytest.FixtureRequest) -> int:
     return request.param
 
 
-@pytest.fixture(params=BLOCK_SIZE, autouse=True)
-def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
-    """Returns some random complex boundary blocks."""
-    size = request.param * 2
-    # Generate a decaying random complex array.
-    arr = xp.triu(xp.arange(size, 0, -1) + xp.arange(size)[:, xp.newaxis])
-    arr = arr.astype(xp.complex128)
-    arr += arr.T
-    arr **= 2
-    # Add some noise.
-    arr += xp.random.rand(size, size) * arr + 1j * xp.random.rand(size, size) * arr
-    # Normalize.
-    arr /= size**2
-    # Make it diagonally dominant.
-    xp.fill_diagonal(arr, xp.abs(arr.sum(-1) + arr.diagonal()))
+ENERGIES = [[-10, -5, 0]]
 
-    blocks = _block_view(_block_view(arr, -1, 2), -2, 2)
-    return blocks[1, 0], blocks[0, 0], blocks[0, 1]
+
+@pytest.fixture(params=ENERGIES, autouse=True)
+def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
+    """Returns some CNT boundary blocks."""
+
+    energies = xp.array(request.param)
+
+    try:
+        fetch_example("carbon-nanotube:")
+    except Exception as e:
+        pytest.fail(f"fetch-example failed: {e}")
+
+    _, _, example_path = get_example_dir("carbon-nanotube:")
+
+    quatrex_config_path = example_path / "quatrex_config.toml"
+    quatrex_config = parse_quatrex_config(quatrex_config_path)
+
+    # hack to configure the communicator
+    CommConfig()
+
+    hamiltonian_sparray = distributed_load(
+        quatrex_config.input_dir / "hamiltonian.npz"
+    ).astype(xp.complex128)
+    block_sizes = get_host(
+        distributed_load(quatrex_config.input_dir / "block_sizes.npy")
+    )
+    hamiltonian_sparray = hamiltonian_sparray.toarray()
+
+    block_size = block_sizes[0]
+
+    H00 = hamiltonian_sparray[:block_size, :block_size]
+    H01 = hamiltonian_sparray[:block_size, block_size : 2 * block_size]
+    H10 = H01.conj().T
+
+    # this examples does not have a overlap matrix
+    M00 = xp.eye(block_size, dtype=xp.complex128)[xp.newaxis, :, :]
+    M00 = M00 * (energies[:, xp.newaxis, xp.newaxis] + 1j * 1e-7)
+
+    M00 -= H00
+    M01 = xp.repeat(-H01[xp.newaxis, :, :], len(energies), axis=0)
+    M10 = xp.repeat(-H10[xp.newaxis, :, :], len(energies), axis=0)
+
+    return M10, M00, M01
 
 
 @pytest.fixture(params=CONTACTS, autouse=True)
 def contact(request: pytest.FixtureRequest) -> str:
     """Returns a contact."""
-    return request.param
-
-
-@pytest.fixture(params=TWO_SIDED)
-def two_sided(request: pytest.FixtureRequest) -> bool:
-    """Whether only right eigenvectors or both are used."""
-    return request.param
-
-
-@pytest.fixture(params=TREAT_PAIRWISE)
-def treat_pairwise(request: pytest.FixtureRequest) -> bool:
-    """Whether the eigenvalues are pairwise filtered."""
-    return request.param
-
-
-@pytest.fixture(params=RESIDUAL_NORMALIZATION_FORMULAS)
-def residual_normalization(request: pytest.FixtureRequest) -> str | None:
-    """Returns a residual normalization formula."""
     return request.param

--- a/tests/qttools/obc/conftest.py
+++ b/tests/qttools/obc/conftest.py
@@ -4,11 +4,10 @@ import pytest
 
 from qttools import NDArray, xp
 from qttools.nevp import NEVP, Beyn, Full
-from qttools.utils.gpu_utils import get_host
-from qttools.utils.mpi_utils import distributed_load
 from quatrex.cli.main import fetch_example
 from quatrex.core.compute_config import CommConfig
 from quatrex.core.quatrex_config import parse_config as parse_quatrex_config
+from quatrex.electron.solver import ElectronSolver
 from quatrex.examples import get_example_dir
 
 NEVP_SOLVERS = [
@@ -74,7 +73,7 @@ def batch_size(request: pytest.FixtureRequest) -> int:
 ENERGIES = [[-10, -5, 0]]
 
 
-@pytest.fixture(params=ENERGIES, autouse=True)
+@pytest.fixture(params=ENERGIES, autouse=True, scope="session")
 def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
     """Returns some CNT boundary blocks."""
 
@@ -93,12 +92,7 @@ def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
     # hack to configure the communicator
     CommConfig()
 
-    hamiltonian_sparray = distributed_load(
-        quatrex_config.input_dir / "hamiltonian.npz"
-    ).astype(xp.complex128)
-    block_sizes = get_host(
-        distributed_load(quatrex_config.input_dir / "block_sizes.npy")
-    )
+    hamiltonian_sparray, block_sizes = ElectronSolver.load_hamiltonian(quatrex_config)
     hamiltonian_sparray = hamiltonian_sparray.toarray()
 
     block_size = block_sizes[0]

--- a/tests/qttools/obc/test_sancho_rubio.py
+++ b/tests/qttools/obc/test_sancho_rubio.py
@@ -8,20 +8,19 @@ from qttools.obc import OBCMemoizer, SanchoRubio
 
 def test_convergence(a_xx: tuple[NDArray, ...], contact: str):
     """Tests that the OBC return the correct result."""
-    sancho_rubio = SanchoRubio()
+    sancho_rubio = SanchoRubio(convergence_tol=1e-10)
     a_ji, a_ii, a_ij = a_xx
+    a_ji, a_ii, a_ij = a_ji[0], a_ii[0], a_ij[0]
+    assert a_ji.ndim == a_ii.ndim == a_ij.ndim == 2
     x_ii = sancho_rubio(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
     assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij))
 
 
 def test_convergence_batch(a_xx: tuple[NDArray, ...], contact: str):
     """Tests that the OBC return the correct result."""
-    sancho_rubio = SanchoRubio()
+    sancho_rubio = SanchoRubio(convergence_tol=1e-10)
     a_ji, a_ii, a_ij = a_xx
-    factors = xp.random.rand(10)
-    a_ji = xp.stack([f * a_ji for f in factors])
-    a_ii = xp.stack([f * a_ii for f in factors])
-    a_ij = xp.stack([f * a_ij for f in factors])
+    assert a_ji.ndim == a_ii.ndim == a_ij.ndim == 3
     x_ii = sancho_rubio(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
     assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij))
 
@@ -36,16 +35,16 @@ def test_max_iterations(a_xx: tuple[NDArray, ...]):
 
 def test_memoizer(a_xx: tuple[NDArray, ...], contact: str):
     """Tests that the Memoization works."""
-    spectral = SanchoRubio()
+    spectral = SanchoRubio(convergence_tol=1e-10)
     spectral = OBCMemoizer(spectral)
     a_ji, a_ii, a_ij = a_xx
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
     assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=1e-5)
 
     # Add a little noise to the input matrices.
-    a_ji += xp.random.randn(*a_ji.shape)
-    a_ii += xp.random.randn(*a_ii.shape)
-    a_ij += xp.random.randn(*a_ij.shape)
+    a_ji = a_ji * (1 + 1e-6)
+    a_ii = a_ii * (1 + 1e-6)
+    a_ij = a_ij * (1 + 1e-6)
 
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
     assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=1e-5)

--- a/tests/qttools/obc/test_spectral.py
+++ b/tests/qttools/obc/test_spectral.py
@@ -3,7 +3,6 @@
 import pytest
 
 from qttools import NDArray, xp
-from qttools.datastructures.dsdbsparse import _block_view
 from qttools.nevp import NEVP
 from qttools.obc import OBCMemoizer, Spectral
 
@@ -28,81 +27,111 @@ def _make_periodic(
     """
     if block_sections == 1:
         return a_xx
-    layer = xp.concatenate(a_xx, axis=-1)
-    view = _block_view(_block_view(layer, -1, 3 * block_sections), -2, block_sections)
-    # Make periodic layers.
-    for i in range(block_sections):
-        view[i, :] = xp.roll(view[0, :], i, axis=0)
 
-    layer = xp.concatenate(xp.concatenate(view, axis=-2), axis=-1)
-    return xp.array_split(layer, 3, axis=-1)
+    a_ji, a_ii, a_ij = a_xx
+
+    # repeat the blocks to create a layer with block_sections
+    block_size = a_ii.shape[-1] * block_sections
+    batch_size = a_ii.shape[0] if a_ii.ndim == 3 else 1
+    a_ii_hat = xp.zeros((batch_size, block_size, block_size), dtype=a_ii.dtype)
+    a_ij_hat = xp.zeros_like(a_ii_hat)
+    a_ji_hat = xp.zeros_like(a_ii_hat)
+
+    for i in range(block_sections):
+        a_ii_hat[
+            :,
+            i * a_ii.shape[-1] : (i + 1) * a_ii.shape[-1],
+            i * a_ii.shape[-1] : (i + 1) * a_ii.shape[-1],
+        ] = a_ii
+        if i < block_sections - 1:
+            a_ii_hat[
+                :,
+                i * a_ij.shape[-1] : (i + 1) * a_ij.shape[-1],
+                (i + 1) * a_ij.shape[-1] : (i + 2) * a_ij.shape[-1],
+            ] = a_ij
+            a_ii_hat[
+                :,
+                (i + 1) * a_ji.shape[-1] : (i + 2) * a_ji.shape[-1],
+                i * a_ji.shape[-1] : (i + 1) * a_ji.shape[-1],
+            ] = a_ji
+
+    a_ji_hat[
+        :,
+        0 : a_ji.shape[-1],
+        (block_sections - 1) * a_ji.shape[-1] : block_sections * a_ji.shape[-1],
+    ] = a_ji
+    a_ij_hat[
+        :,
+        (block_sections - 1) * a_ij.shape[-1] : block_sections * a_ij.shape[-1],
+        0 : a_ij.shape[-1],
+    ] = a_ij
+
+    return a_ji_hat, a_ii_hat, a_ij_hat
 
 
 @pytest.mark.usefixtures(
     "nevp",
     "x_ii_formula",
     "block_sections",
-    "two_sided",
-    "treat_pairwise",
-    "residual_normalization",
 )
 def test_correctness(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,
     block_sections: int,
     x_ii_formula: str,
-    contact: str,
-    two_sided: bool,
-    treat_pairwise: bool,
-    residual_normalization: str | None,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
         nevp=nevp,
         block_sections=block_sections,
         x_ii_formula=x_ii_formula,
-        two_sided=two_sided,
-        treat_pairwise=treat_pairwise,
-        residual_normalization=residual_normalization,
+        treat_pairwise=False,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
-    x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
-    assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=1e-5)
+    a_ji, a_ii, a_ij = a_ji[0], a_ii[0], a_ij[0]
+    x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact="left")
+    assert xp.all(
+        (
+            xp.linalg.norm(
+                x_ii - xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), axis=(-1, -2)
+            )
+            / xp.linalg.norm(x_ii, axis=(-1, -2))
+        )
+        < 5e-3
+    )
 
 
 @pytest.mark.usefixtures(
     "nevp",
     "x_ii_formula",
     "block_sections",
-    "two_sided",
-    "treat_pairwise",
-    "residual_normalization",
 )
 def test_correctness_batch(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,
     block_sections: int,
     x_ii_formula: str,
-    contact: str,
-    two_sided: bool,
-    treat_pairwise: bool,
-    residual_normalization: str,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
         nevp=nevp,
         block_sections=block_sections,
         x_ii_formula=x_ii_formula,
-        two_sided=two_sided,
-        treat_pairwise=treat_pairwise,
-        residual_normalization=residual_normalization,
+        treat_pairwise=False,
+        residual_tolerance=1e-1,
+        max_decay=20,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
-    a_ji = xp.stack([a_ji for __ in range(10)])
-    a_ii = xp.stack([a_ii for __ in range(10)])
-    a_ij = xp.stack([a_ij for __ in range(10)])
-    x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
-    assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=1e-5)
+    x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact="left")
+    assert xp.all(
+        (
+            xp.linalg.norm(
+                x_ii - xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), axis=(-1, -2)
+            )
+            / xp.linalg.norm(x_ii, axis=(-1, -2))
+        )
+        < 5e-3
+    )
 
 
 @pytest.mark.usefixtures(
@@ -119,20 +148,48 @@ def test_memoizer(
 ):
     """Tests that the Memoization works."""
     spectral = Spectral(
-        nevp=nevp, block_sections=block_sections, x_ii_formula=x_ii_formula
+        nevp=nevp,
+        block_sections=block_sections,
+        x_ii_formula=x_ii_formula,
+        treat_pairwise=False,
+        residual_tolerance=1e-1,
+        max_decay=20,
     )
     spectral = OBCMemoizer(spectral, memoizing_mode="force-after-first")
-    a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
-    x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
-    assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=1e-5)
+
     # Add a little noise to the input matrices.
-    a_ji += 1e-2 * xp.random.randn(*a_ji.shape)
-    a_ii += 1e-2 * xp.random.randn(*a_ii.shape)
-    a_ij += 1e-2 * xp.random.randn(*a_ij.shape)
-    a_ji, a_ii, a_ij = _make_periodic((a_ji, a_ii, a_ij), block_sections)
+    a_ji, a_ii, a_ij = a_xx
+    a_ji_hat = a_ji * (1 + 1e-6)
+    a_ii_hat = a_ii * (1 + 1e-6)
+    a_ij_hat = a_ij * (1 + 1e-6)
+
+    a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
+    a_ji_hat, a_ii_hat, a_ij_hat = _make_periodic(
+        (a_ji_hat, a_ii_hat, a_ij_hat), block_sections
+    )
 
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
-    assert xp.allclose(x_ii, xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), atol=2e-5)
+    assert xp.all(
+        (
+            xp.linalg.norm(
+                x_ii - xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), axis=(-1, -2)
+            )
+            / xp.linalg.norm(x_ii, axis=(-1, -2))
+        )
+        < 5e-3
+    )
+
+    x_ii = spectral(a_ii=a_ii_hat, a_ij=a_ij_hat, a_ji=a_ji_hat, contact=contact)
+    assert xp.all(
+        (
+            xp.linalg.norm(
+                x_ii - xp.linalg.inv(a_ii_hat - a_ji_hat @ x_ii @ a_ij_hat),
+                axis=(-1, -2),
+            )
+            / xp.linalg.norm(x_ii, axis=(-1, -2))
+        )
+        < 5e-3
+    )
 
 
 @pytest.mark.usefixtures(
@@ -176,12 +233,10 @@ def test_upscaling(
 
 @pytest.mark.usefixtures(
     "nevp",
-    "two_sided",
 )
 def test_compute_dE_dk(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,
-    two_sided: bool,
 ):
     """Tests that the eigenmode upscaling works."""
 
@@ -192,7 +247,7 @@ def test_compute_dE_dk(
     block_size = a_xx[0].shape[-1]
     b = len(a_xx) // 2
 
-    spectral = Spectral(nevp=nevp, two_sided=two_sided)
+    spectral = Spectral(nevp=nevp)
 
     rng = xp.random.default_rng()
 
@@ -204,14 +259,7 @@ def test_compute_dE_dk(
         (batch_size, block_size, block_size)
     )
 
-    if two_sided:
-        vls = rng.random((batch_size, block_size, block_size)) + 1j * rng.random(
-            (batch_size, block_size, block_size)
-        )
-    else:
-        vls = None
-
-    dEk_dk = spectral._compute_dE_dk(ws, vrs, a_xx, vls=vls)
+    dEk_dk = spectral._compute_dE_dk(ws, vrs, a_xx)
 
     dEk_dk_ref = xp.zeros_like(ws)
     for i in range(batch_size):
@@ -220,12 +268,8 @@ def test_compute_dE_dk(
                 (1j * n) * w**n * a_xn[i] for a_xn, n in zip(a_xx, range(-b, b + 1))
             )
 
-            if two_sided:
-                phi_right = vrs[i, :, j]
-                phi_left = vls[i, :, j]
-            else:
-                phi_right = vrs[i, :, j]
-                phi_left = vrs[i, :, j]
+            phi_right = vrs[i, :, j]
+            phi_left = vrs[i, :, j]
 
             dEk_dk_ref[i, j] = phi_left.conj().T @ a @ phi_right
 


### PR DESCRIPTION
This refactored the obc tests to use data from the CNT example.
The example is fetched in the conftest and contact blocks are extracted.

Additionally, tests of non-recommended features are removed.