### PR TITLE
Improved filtering for ballistic simulations

### DIFF
--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -294,6 +294,10 @@ class Spectral(OBCSolver):
 
             mask_injected = dEk_dk.real > 0
             mask_injected &= xp.abs(ks.imag) < self.min_decay
+            mask_injected &= self.min_propagation < abs(dEk_dk.real) / (
+                abs(dEk_dk.imag) + eta
+            )
+
             dEk_dK_injected = dEk_dk[mask_injected]
 
             return mask_reflected, mask_injected, dEk_dK_injected

--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -53,6 +53,9 @@ class Spectral(OBCSolver):
         The tolerance for the residual of the NEVP.
     residual_normalization : bool
         If the residual should be normalized by the eigenvalue.
+    eta_decay : float, optional
+        Small value to separate very slow decaying modes from
+        non-decaying ones.
 
         [^1]: S. Brück, et al., Efficient algorithms for large-scale
         quantum transport calculations, The Journal of Chemical Physics,
@@ -71,6 +74,7 @@ class Spectral(OBCSolver):
         residual_tolerance: float = 1e-3,
         residual_normalization: bool = True,
         warning_threshold: float = 1e-1,
+        eta_decay: float = 1e-14,
     ) -> None:
         """Initializes the spectral OBC solver."""
         self.nevp = nevp
@@ -85,6 +89,7 @@ class Spectral(OBCSolver):
         self.residual_tolerance = residual_tolerance
         self.residual_normalization = residual_normalization
         self.warning_threshold = warning_threshold
+        self.eta_decay = eta_decay
 
     def _extract_subblocks(
         self,
@@ -270,6 +275,12 @@ class Spectral(OBCSolver):
 
         # Make sure decaying modes decay fast enough.
         mask_decaying = ks.imag < -self.min_decay
+
+        # capture slow decaying modes
+        # modes that arent clearly propagating
+        mask_decaying |= (
+            self.min_propagation >= abs(dEk_dk.real) / (abs(dEk_dk.imag) + eta)
+        ) & (ks.imag < -self.eta_decay)
 
         # ingore modes that decay incredibly fast
         mask_decaying &= ks.imag > -self.max_decay

--- a/src/quatrex/core/quatrex_config.py
+++ b/src/quatrex/core/quatrex_config.py
@@ -234,6 +234,17 @@ class OBCConfig(BaseModel):
     $$ \lvert \mathbf{g} - [\mathbf{M}_{0} - \mathbf{M}_{-1} \mathbf{g} \mathbf{M}_{1} ]^{-1} \rvert / \lvert \mathbf{g} \rvert $$
     """
 
+    eta_decay: PositiveFloat = 1e-12
+    """Small value to separate very slow decaying modes from
+        non-decaying ones in the spectral OBC solver.
+
+    Modes that are very close to the unit contour could be misclassified
+    with 'min_decay' and 'min_propagation' conditions i.e. 
+    when their decay is smaller than 'min_decay' but they are not propagating fast enough.
+    The not fast enough propagating ones with decay smaller than 'eta_decay' are 
+    considered as well decaying modes.
+    """
+
     # Parameters for iterative OBC algorithms.
     max_iterations: PositiveInt = 100
     """The maximum number of iterations for the Sancho-Rubio method."""

--- a/src/quatrex/core/subsystem.py
+++ b/src/quatrex/core/subsystem.py
@@ -131,6 +131,7 @@ class SubsystemSolver(ABC):
                 residual_tolerance=obc_config.residual_tolerance,
                 residual_normalization=obc_config.residual_normalization,
                 warning_threshold=obc_config.warning_threshold,
+                eta_decay=obc_config.eta_decay,
             )
 
         else:


### PR DESCRIPTION
This add an extra condition to capture slow decaying modes in the obc filtering.
This helps to reduce the recursion error in the obc in the ballistic case.