### PR TITLE
Fix typo in print statement and correct index in Contact class

### DIFF
--- a/src/quatrex/device/contact.py
+++ b/src/quatrex/device/contact.py
@@ -113,7 +113,7 @@ class Contact:
         if comm.rank == 0:
             print(f"Contact {self.name}:", flush=True)
             print(
-                f"    Number of atoms inside the origin cell: {self.origin_num_orbitals}",
+                f"    Number of orbitals inside the origin cell: {self.origin_num_orbitals}",
                 flush=True,
             )
 
@@ -426,7 +426,7 @@ class Contact:
             range(ny),
             range(nz),
         ):
-            index = [idy - self.origin_cell_offset[0], idz - self.origin_cell_offset[0]]
+            index = [idy - self.origin_cell_offset[0], idz - self.origin_cell_offset[1]]
             index.insert(self.direction, transport_index)
 
             # Process atom and orbital indices


### PR DESCRIPTION
This pull request makes two small but important corrections to the `src/quatrex/device/contact.py` file. The first is a wording fix in a printed message for clarity, and the second is a bug fix in the calculation of orbital indices.

- Output and messaging improvements:
  * Changed the print statement in the `__init__` method to refer to "Number of orbitals" instead of "Number of atoms" for accuracy.

- Bug fix:
  * Corrected the calculation of the `index` in `_init_orbitals_transverse` by using the correct offset for the second dimension, fixing an indexing bug.