### PR TITLE
Input bugs

### DIFF
--- a/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
@@ -1,0 +1,117 @@
+simulation_dir = "."
+input_dir = "../inputs"
+
+formalism = "negf" # "negf" or "wf"
+
+[device]
+transport_direction = 'z'
+construct_from_unit_cell = true
+num_transport_cells = 12
+neighbor_cell_cutoff = [0, 0, 2]
+
+[scba] # ===============================================================
+max_iterations = 2
+mixing_factor = 0.5
+
+coulomb_screening = true
+phonon = true
+
+symmetric = true
+
+[outputs] # Select which outputs to write.
+electron_ldos = true
+contact_currents = true
+device_currents = true
+electron_density = true
+hole_density = true
+
+polarization_density = true
+coulomb_screening_density = true
+
+self_energy_density = true
+
+# If enabled, the profiling stats will take a bit of time to crunch the
+# numbers.
+save_profiling_results = true
+
+
+[electron] # ===========================================================
+# 0.2 V Potential difference.
+left_fermi_level = -3.6  # eV
+right_fermi_level = -3.8 # eV
+
+fermi_level = -3.6                        # eV
+conduction_band_edge = -3.566382123573606 # eV
+valence_band_edge = -4.174109778287768    # eV
+
+band_edge_tracking = "eigenvalues"
+
+# Energy grid.
+energy_window_min = -10
+energy_window_max = 0
+energy_window_num = 100
+
+solver.algorithm = "rgf"
+solver.max_batch_size = 1000
+solver.compute_current = true # Compute Meir-Wingreen current.
+
+obc.algorithm = "spectral"
+obc.nevp_solver = "full"
+obc.block_sections = 2
+
+# Parameters for Beyn's method.
+obc.num_ref_iterations = 3
+obc.max_decay = 15
+obc.min_decay = 1e-3
+obc.r_o = 10
+obc.r_i = 0.8
+obc.m_0 = 31
+obc.num_quad_points = 31
+
+obc.memoizer.mode = "auto"
+obc.memoizer.num_ref_iterations = 3
+obc.memoizer.relative_tol = 1e-2
+obc.memoizer.absolute_tol = 1e-8
+obc.residual_tolerance = 1e-4
+
+[coulomb_screening] # ==================================================
+interaction_cutoff = 8 # Å
+epsilon_r = 4
+
+num_connected_blocks = 1 # Can be 1, 2, 3, or "auto"
+
+solver.algorithm = "rgf"
+solver.max_batch_size = 1000
+
+obc.algorithm = "spectral"
+obc.nevp_solver = "full"
+obc.block_sections = 2
+
+# Parameters for Beyn's method.
+obc.num_ref_iterations = 3
+obc.max_decay = 15
+obc.min_decay = 1e-3
+obc.r_o = 10
+obc.r_i = 0.8
+obc.m_0 = 32
+obc.num_quad_points = 31
+obc.residual_tolerance = 1e-4
+
+obc.memoizer.mode = "auto"
+obc.memoizer.num_ref_iterations = 3
+obc.memoizer.relative_tol = 1e-2
+obc.memoizer.absolute_tol = 1e-8
+
+lyapunov.algorithm = "spectral"
+
+lyapunov.memoizer.mode = "auto"
+lyapunov.memoizer.num_ref_iterations = 3
+lyapunov.memoizer.relative_tol = 2e-1
+lyapunov.memoizer.absolute_tol = 1e-6
+
+
+[phonon]
+interaction_cutoff = 5.5     # Å
+model = "pseudo-scattering"
+phonon_energy = 50e-3
+deformation_potential = 5e-3

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/device_current_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/device_current_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4066233eef31886823001c4327bed08251898b31937a803ab0553e4c82f8ea2
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/device_current_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/device_current_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a223609f89ea9d736cbeae79ae4b76125ba7f5accd2e588fb73e6aebc8ac210
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4decb2f8f3b8c321ebba8d71747f1af79bb92d4d38af2ff344ddaab33b98347
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3e37169fd6f0ba1228b34b919249098a7d326f4fd20cc1d26fed95eafa287e3
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_ldos_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_ldos_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e453f6f8f77221bfb17d82831a89b9d4a48890572adf81e4671daf410e9b845
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_ldos_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_ldos_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb0be86b1f87b1f5fe9167a2211a0d111a94efdfd0a05013cea2ab4b26a083ab
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/hole_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/hole_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffe28d8a6e64a1e945df7aece8d4ec197ee8ecf68a63ac504d03a9b9b701ea71
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/hole_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/hole_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea8531c1078831a88d0fe36b8f52be4804ca709a3dbb4391b3505534c4d0280
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4066233eef31886823001c4327bed08251898b31937a803ab0553e4c82f8ea2
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a223609f89ea9d736cbeae79ae4b76125ba7f5accd2e588fb73e6aebc8ac210
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:122b7ad06ae8f78d6cb55f8fa5bba86c70e62604a27be2c7dcf8c1533613b858
+size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fa1358f5679c792755493b31cfe7eba80dfbfa6709df84996a64c85e64e6fa9
+size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e5334f8362c99f0da2817f73b4dac183930d1ed86bcbbb97322c58b55f01156
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63e395e5433364738065aa566a351e50476f5e1f35e6283ea33a34b5d2cee48c
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185616c9b416b591aad5b3bd035a28dc006e2a1e1b2bc2fa9273b06e3edaae15
+size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da44b0dccdbb61b40275d0ec4703cfc0a08bb03f525d88d06935e547202f803
+size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e5334f8362c99f0da2817f73b4dac183930d1ed86bcbbb97322c58b55f01156
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63e395e5433364738065aa566a351e50476f5e1f35e6283ea33a34b5d2cee48c
+size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_greater_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_greater_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49d5d14719ec7bbfb58d74abfd91f7f2cca3bdf3d16c5dbbc4e75135577681d
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_greater_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_greater_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:310f1600591d83c04cf2f59209ba5fa412a0b5ddaaabf005aeea5dd3482c662c
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_lesser_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_lesser_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:974a6d97613c8888cf3ece65e678798e20523af27e237a0435e023bd028134c5
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_lesser_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_lesser_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a60e962b47d32108e37d5cac547c6a4735e67de3d55ca8f239bacf83a9e1c5d
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e04dfa1403c3a78031058c16101d722cc65d9cf430a52488e4c63cf72394eab
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b917f6750ba3a0c5b1e0eae4dde330eb9004496a82024828d8bfb7f6faa368
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_greater_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_greater_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d160e1b6dba13067f313d42efe924e6246be6ebb79cb66713dce8debcdf2c1f5
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_greater_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_greater_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a157dee8de6c6e508169e2984601abe7792786610a1e50c40a8824b9ed65a8d2
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_lesser_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_lesser_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:521b52e370c1b240eb58f2d66927d3e69a0b35dd6ac863726692c27a954821cc
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_lesser_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_lesser_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d0d67e31f812d60e295605018f5c10dba72c9d4b8bf1820e163d89fa4bc871e
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d160e1b6dba13067f313d42efe924e6246be6ebb79cb66713dce8debcdf2c1f5
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f4be6497e24873fc6f18b8d3419e372b5b8fad1e7b9ca229eda0cdc0ca0e69f
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_greater_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_greater_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8920e27baa1e7e0230df07d5ceb0f2afc8c943a27619088b27a45bc75cd8499a
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_greater_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_greater_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d2a0c05673cbadf4b47bae442a4b2fdc404f8723e5a25561450894eab1037c4
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_lesser_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_lesser_density_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fa42d873f24fec8ad5450bcff94f0351490ca663b659270f12ed31ca20870b5
+size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_lesser_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/w_lesser_density_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34fccd0bfdd2e6b56c10e8f6a9175489e48cf6d5296a57859add88e356f90976
+size 614528

--- a/examples/w90/carbon-nanotube/inputs/coulomb_matrix_unit_cells.npy
+++ b/examples/w90/carbon-nanotube/inputs/coulomb_matrix_unit_cells.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33f7d11bfe3d2a5d0f86c7f61f51ff8e354e66ce673e9ff303a1198aa236cbb3
+size 172160

--- a/examples/w90/carbon-nanotube/inputs/hamiltonian_unit_cells.npy
+++ b/examples/w90/carbon-nanotube/inputs/hamiltonian_unit_cells.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ccdb6e3f0f2c49e2ea891c940f3a7a4b98c2ff97866852d7b57d3e128d735a8
+size 172160

--- a/examples/w90/carbon-nanotube/inputs/lattice_vectors.npy
+++ b/examples/w90/carbon-nanotube/inputs/lattice_vectors.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69b7a16de6cf5cbc1c659959f38e27ec6ae269a9f74cbba70870c647491dcb1d
+size 200

--- a/examples/w90/carbon-nanotube/inputs/wannier_centers.npy
+++ b/examples/w90/carbon-nanotube/inputs/wannier_centers.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929a393bee68372630fd61ac349e9dd1b312be04dc0da89c0f24360df35d96f1
+size 896

--- a/src/quatrex/device/inputs.py
+++ b/src/quatrex/device/inputs.py
@@ -413,7 +413,8 @@ def _assemble_kpoint(
             stack_index = tuple(stack_index[index])
 
             cells = np.array(list(matrix_dict.keys()))
-            phases = xp.exp(2j * xp.pi * (cells @ kpoint))
+            phases = np.exp(2j * np.pi * (cells @ kpoint))
+            phases = xp.asarray(phases)
 
             # NOTE: Sparse matrix addition is slow
             # but unavoidable due to memory constraints.

--- a/src/quatrex/device/inputs.py
+++ b/src/quatrex/device/inputs.py
@@ -386,7 +386,7 @@ def _assemble_kpoint(
     num_dimensions = len(kpoint_grid)
 
     if isinstance(kshift, int):
-        kshift = xp.array([kshift for _ in range(num_dimensions)])
+        kshift = np.array([kshift for _ in range(num_dimensions)])
 
     if not matrix_dict:
         raise ValueError("No matrices found in matrix_dict.")
@@ -403,22 +403,25 @@ def _assemble_kpoint(
     )
     kpoints = np.roll(kpoints, shift=kshift, axis=tuple(range(num_dimensions)))
 
-    index = np.argwhere(kpoint_grid > 1)[0]
-    for stack_index in np.ndindex(kpoints.shape[:-1]):
-        kpoint = kpoints[stack_index]
-        stack_index = np.array(stack_index)
-        stack_index = tuple(stack_index[index])
+    if all(kpoint_grid == 1):
+        out_matrix.stack[(...,)] += sum(matrix_dict.values())
+    else:
+        index = np.argwhere(kpoint_grid > 1)[0]
+        for stack_index in np.ndindex(kpoints.shape[:-1]):
+            kpoint = kpoints[stack_index]
+            stack_index = np.array(stack_index)
+            stack_index = tuple(stack_index[index])
 
-        cells = np.array(list(matrix_dict.keys()))
-        phases = xp.exp(2j * xp.pi * (cells @ kpoint))
+            cells = np.array(list(matrix_dict.keys()))
+            phases = xp.exp(2j * xp.pi * (cells @ kpoint))
 
-        # NOTE: Sparse matrix addition is slow
-        # but unavoidable due to memory constraints.
-        # TODO: Could still be optimized
-        matrix_contribution = sum(
-            [phase * matrix for phase, matrix in zip(phases, matrix_dict.values())]
-        )
-        out_matrix.stack[(...,) + stack_index] += matrix_contribution
+            # NOTE: Sparse matrix addition is slow
+            # but unavoidable due to memory constraints.
+            # TODO: Could still be optimized
+            matrix_contribution = sum(
+                [phase * matrix for phase, matrix in zip(phases, matrix_dict.values())]
+            )
+            out_matrix.stack[(...,) + stack_index] += matrix_contribution
 
 
 def _create_matrix_from_unit_cells(

--- a/src/quatrex/device/inputs.py
+++ b/src/quatrex/device/inputs.py
@@ -2,7 +2,6 @@
 
 import warnings
 from copy import copy
-from typing import Callable
 
 import numpy as np
 
@@ -525,10 +524,9 @@ def load_matrix(
     matrix_name: str,
     sparsity_pattern: sparse.coo_matrix | None = None,
     shift_kpoints: bool = False,
-    symmetry_op: Callable = xp.conj,
 ) -> tuple[DSDBSparse, sparse.coo_matrix]:
-    """Loads a matrix from file, applying symmetrization and optionally
-    using a provided sparsity pattern.
+    """Loads a hermitain matrix from file and optionally
+    apply a provided sparsity pattern.
 
     Parameters
     ----------
@@ -542,8 +540,6 @@ def load_matrix(
     shift_kpoints : bool
         Whether to "shift"/"center" the kpoints in the allocated
         DSDBSparse.
-    symmetry_op : Callable, optional
-        The symmetry operation to apply, by default xp.conj
 
     Returns
     -------
@@ -574,7 +570,10 @@ def load_matrix(
         sparsity_pattern = sparsity_pattern + sparsity_pattern.T
 
     # Symmetrize the data.
-    matrix_sparray = 0.5 * (matrix_sparray + symmetry_op(matrix_sparray).T)
+    # TODO: This should be avoided due to the extra copy
+    # when addressing issue #214, only the upper part should be kept
+    # as only symmetric matrices are loaded
+    matrix_sparray = 0.5 * (matrix_sparray + matrix_sparray.T.conj())
 
     matrix = config.compute.dsdbsparse_type.from_sparray(
         sparsity_pattern.astype(xp.complex128),
@@ -582,7 +581,7 @@ def load_matrix(
         global_stack_shape=(comm.stack.size,)
         + tuple([k for k in config.device.kpoint_grid if k > 1]),
         symmetry=config.scba.symmetric,
-        symmetry_op=symmetry_op,
+        symmetry_op=xp.conj,
     )
     matrix.data[:] = 0.0  # Initialize to zero.
     if matrix_dict is None:

--- a/src/quatrex/device/inputs.py
+++ b/src/quatrex/device/inputs.py
@@ -529,8 +529,8 @@ def load_matrix(
     sparsity_pattern: sparse.coo_matrix | None = None,
     shift_kpoints: bool = False,
 ) -> tuple[DSDBSparse, sparse.coo_matrix]:
-    """Loads a hermitain matrix from file and optionally
-    apply a provided sparsity pattern.
+    """Loads a Hermitian matrix from file and optionally
+    applies a provided sparsity pattern.
 
     Parameters
     ----------


### PR DESCRIPTION
There were multiple bugs which led to the code not working with gamma only and on the GPU.
These bugs are adressed in this PR:
- Not only check `index = np.argwhere(kpoint_grid > 1)[0]`, but checking for all ones.
- Replacing `xp` with `np` if needed.
- Removing `xp.conj` on a sparse matrix.
- Adding a gamma only example.