### PR TITLE
Change cupyx.jit import and usage in operator.py

### DIFF
--- a/src/qttools/kernels/operator.py
+++ b/src/qttools/kernels/operator.py
@@ -4,11 +4,11 @@ from qttools import QTX_USE_CUPY_JIT, NDArray, xp
 from qttools.kernels import linalg
 
 if xp.__name__ == "cupy":
-    import cupyx as cpx
+    from cupyx import jit
 
     if QTX_USE_CUPY_JIT:
 
-        @cpx.jit.rawkernel()
+        @jit.rawkernel()
         def _contour_operator(
             output: NDArray,
             a_xx: NDArray,
@@ -20,7 +20,7 @@ if xp.__name__ == "cupy":
         ):
             # assumes c order of output and a_xx
 
-            idx = int(cpx.jit.blockIdx.x * cpx.jit.blockDim.x + cpx.jit.threadIdx.x)
+            idx = int(jit.blockIdx.x * jit.blockDim.x + jit.threadIdx.x)
             if idx < batchsize * num_quatrature_points * blocksize * blocksize:
 
                 # batch index


### PR DESCRIPTION
Import resolution changed in new version of cupy, making things break here on GPU. This should work both with old and new version.

In the other files implementing `jit.rawkernel`s we were already doing `from cupyx import jit` so no changes there.