### PR TITLE
Try to improve the sparsity reduction in the full NEVP solver

### DIFF
--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -3,6 +3,7 @@
 import warnings
 
 from qttools import NDArray, sparse, xp
+from qttools.comm import comm
 from qttools.kernels import linalg
 from qttools.nevp.nevp import NEVP
 
@@ -51,21 +52,23 @@ class Full(NEVP):
 
         if reduce:
             if a_xx_sparsity is None:
-                warnings.warn(
-                    "Reduction is enabled but no coefficient blocks are provided. "
-                    "Zero columns will be identified at runtime, which may "
-                    "introduce overhead.",
-                )
+                if comm.rank == 0:
+                    warnings.warn(
+                        "Reduction is enabled but no coefficient blocks are provided. "
+                        "Zero columns will be identified at runtime, which may "
+                        "introduce overhead.",
+                    )
             else:
                 self.zero_indices, self.nonzero_indices, self.all_indices = (
                     self._find_zero_columns(a_xx_sparsity)
                 )
 
                 if self.zero_indices is None:
-                    warnings.warn(
-                        "No columns are zero in the first and last blocks. "
-                        "Reduction has no effect.",
-                    )
+                    if comm.rank == 0:
+                        warnings.warn(
+                            "No columns are zero in the first and last blocks. "
+                            "Reduction has no effect.",
+                        )
                     self.reduce = False
 
     @staticmethod
@@ -151,10 +154,11 @@ class Full(NEVP):
 
             if self.zero_indices is None:
                 # No columns are zero.
-                warnings.warn(
-                    "No columns are zero in the first and last blocks. "
-                    "Reduction has no effect.",
-                )
+                if comm.rank == 0:
+                    warnings.warn(
+                        "No columns are zero in the first and last blocks. "
+                        "Reduction has no effect.",
+                    )
                 self.reduce = False
 
         inverse = linalg.inv(sum(a_xx))

--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -59,11 +59,11 @@ class Full(NEVP):
                         "introduce overhead.",
                     )
             else:
-                self.zero_indices, self.nonzero_indices, self.all_indices = (
+                self.zero_inds, self.nonzero_inds, self.all_inds = (
                     self._find_zero_columns(a_xx_sparsity)
                 )
 
-                if self.zero_indices is None:
+                if self.zero_inds is None:
                     if comm.rank == 0:
                         warnings.warn(
                             "No columns are zero in the first and last blocks. "
@@ -89,11 +89,11 @@ class Full(NEVP):
 
         Returns
         -------
-        zero_indices : NDArray or None
+        zero_inds : NDArray or None
             The indices of the zero columns.
-        nonzero_indices : NDArray or None
+        nonzero_inds : NDArray or None
             The indices of the non-zero columns.
-        all_indices : NDArray or None
+        all_inds : NDArray or None
             The concatenation of zero and non-zero column indices.
 
         """
@@ -144,15 +144,13 @@ class Full(NEVP):
         if a_xx[0].ndim > 3:
             a_xx = tuple(a_x.reshape(-1, *a_x.shape[-2:]) for a_x in a_xx)
 
-        if self.reduce and not hasattr(self, "zero_indices"):
+        if self.reduce and not hasattr(self, "zero_inds"):
             # Identify zero columns at runtime if not provided at instantiation.
-            self.zero_indices, self.nonzero_indices, self.all_indices = (
-                self._find_zero_columns(
-                    tuple(sparse.csc_matrix(a_x[0]) for a_x in a_xx)
-                )
+            self.zero_inds, self.nonzero_inds, self.all_inds = self._find_zero_columns(
+                tuple(sparse.csc_matrix(a_x[0]) for a_x in a_xx)
             )
 
-            if self.zero_indices is None:
+            if self.zero_inds is None:
                 # No columns are zero.
                 if comm.rank == 0:
                     warnings.warn(
@@ -175,9 +173,9 @@ class Full(NEVP):
 
         # Concatenate and delete
         if self.reduce:
-            A_b = A[:, self.zero_indices, :][:, :, self.nonzero_indices]
-            A_c = A[:, self.zero_indices, :][:, :, self.zero_indices]
-            A = A[:, self.nonzero_indices, :][:, :, self.nonzero_indices]
+            A_b = A[:, self.zero_inds, :][:, :, self.nonzero_inds]
+            A_c = A[:, self.zero_inds, :][:, :, self.zero_inds]
+            A = A[:, self.nonzero_inds, :][:, :, self.nonzero_inds]
 
         w, v = linalg.eig(
             A,
@@ -194,7 +192,7 @@ class Full(NEVP):
 
             tmp = xp.concatenate([v, v_zero], axis=1)
             v = xp.empty_like(tmp)
-            v[:, self.all_indices, :] = tmp
+            v[:, self.all_inds, :] = tmp
 
         # Recover the original eigenvalues from the spectral transform.
         w = xp.where((xp.abs(w) == 0.0), -1.0, w)

--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from qttools import NDArray, xp
+from qttools import NDArray, sparse, xp
 from qttools.kernels import linalg
 from qttools.nevp.nevp import NEVP
 
@@ -21,16 +21,18 @@ class Full(NEVP):
         The location where to compute the eigenvalues and eigenvectors.
         Can be either "numpy" or "cupy" or "nvmath".
     use_pinned_memory : bool, optional
-        Whether to use pinnend memory if cupy is used.
-        Default is `True`.
-    a_sparsity : tuple[NDArray, ...] | None, optional
-        The sparsity patterns of the coefficient blocks of the NEVP.
-        Every array is a 2D matrix with entries 0 or 1 indicating
-        if the entry is zero or non-zero, respectively.
+        Whether to use pinnend memory if cupy is used. Default is
+       `True`.
     reduce : bool, optional
-        Whether to reduce the problem size by eliminating columns
-        that are zero in the first and last coefficient blocks.
-        These columns correspond to eigenvalues that are infinity or zero.
+        Whether to reduce the problem size by eliminating columns that
+        are zero in the first and last coefficient blocks. These columns
+        correspond to eigenvalues that are infinity or zero.
+    a_xx_sparsity : tuple[sparse.csc_matrix, ...] or None, optional
+        The sparsity patterns of the coefficient blocks of the NEVP.
+        If `reduce` is `True`, this can be provided at instantiation to
+        identify the zero columns and perform the reduction. If `reduce`
+        is `True` and `a_xx` is not provided, the zero columns will be
+        identified at runtime, which may introduce some overhead.
 
     """
 
@@ -38,75 +40,79 @@ class Full(NEVP):
         self,
         eig_compute_location: str = "numpy",
         use_pinned_memory: bool = True,
-        a_sparsity: tuple[NDArray, ...] | None = None,
         reduce: bool = False,
+        a_xx_sparsity: tuple[sparse.csc_matrix, ...] | None = None,
     ):
         """Initializes the Full NEVP solver."""
         self.eig_compute_location = eig_compute_location
         self.use_pinned_memory = use_pinned_memory
 
-        self.zero_indices = None
-        self.nonzero_indices = None
-        self.all_indices = None
-
-        if reduce and a_sparsity is None:
-            raise ValueError(
-                "If reduce is True, a_sparsity must be provided.",
-            )
-
-        if a_sparsity is not None:
-            for a in a_sparsity:
-                if a.ndim != 2:
-                    raise ValueError(
-                        "a_sparsity must be a tuple of 2D arrays.",
-                    )
-                if a.shape[0] != a.shape[1]:
-                    raise ValueError(
-                        "a_sparsity must be a tuple of square arrays.",
-                    )
-
-            assert all(a.shape[0] == a_sparsity[0].shape[0] for a in a_sparsity), (
-                "All arrays in a_sparsity must have the same shape.",
-            )
-
-        if reduce and a_sparsity is not None:
-            # Identify zero columns in the first and last blocks.
-            # by summing along the rows and checking for zeros.
-            column_sum_first = xp.count_nonzero(a_sparsity[0], axis=0)
-            column_sum_last = xp.count_nonzero(a_sparsity[-1], axis=0)
-            zero_indices_first = xp.where(column_sum_first == 0)[0]
-            zero_indices_last = xp.where(column_sum_last == 0)[0]
-
-            # offset last indices by the size of all previous blocks
-            offset = sum(a.shape[1] for a in a_sparsity[:-2])
-
-            self.zero_indices = xp.concatenate(
-                (zero_indices_first, zero_indices_last + offset)
-            )
-
-            self.nonzero_indices = xp.setdiff1d(
-                xp.arange(offset + a_sparsity[-1].shape[1]),
-                self.zero_indices,
-            )
-
-            self.all_indices = xp.concatenate((self.nonzero_indices, self.zero_indices))
-            if len(self.nonzero_indices) == 0 or len(self.nonzero_indices) == 0:
-                raise ValueError(
-                    "All columns are zero in the first or last blocks. "
-                    "This problem is ill-posed.",
-                )
-
-            if len(self.zero_indices) == 0:
-                warnings.warn(
-                    "No columns are zero in the first and last blocks. "
-                    "Reduction has no effect.",
-                )
-                reduce = False
-                self.zero_indices = None
-                self.nonzero_indices = None
-                self.all_indices = None
-
         self.reduce = reduce
+
+        if reduce:
+            if a_xx_sparsity is None:
+                warnings.warn(
+                    "Reduction is enabled but no coefficient blocks are provided. "
+                    "Zero columns will be identified at runtime, which may "
+                    "introduce overhead.",
+                )
+            else:
+                self.zero_indices, self.nonzero_indices, self.all_indices = (
+                    self._find_zero_columns(a_xx_sparsity)
+                )
+
+                if self.zero_indices is None:
+                    warnings.warn(
+                        "No columns are zero in the first and last blocks. "
+                        "Reduction has no effect.",
+                    )
+                    self.reduce = False
+
+    @staticmethod
+    def _find_zero_columns(
+        a_xx: tuple[sparse.csc_matrix, ...],
+    ) -> tuple[NDArray, NDArray, NDArray] | tuple[None, None, None]:
+        """Determines the reduction indices for the full NEVP solver.
+
+        This method identifies the zero columns in the first and last
+        coefficient blocks, which correspond to eigenvalues that are
+        infinity or zero, respectively. It returns the indices of the
+        zero columns, the non-zero columns, and the concatenation of both.
+
+        Parameters
+        ----------
+        a_xx : tuple[sparse.csc_matrix, ...]
+            The coefficient blocks of the NEVP.
+
+        Returns
+        -------
+        zero_indices : NDArray or None
+            The indices of the zero columns.
+        nonzero_indices : NDArray or None
+            The indices of the non-zero columns.
+        all_indices : NDArray or None
+            The concatenation of zero and non-zero column indices.
+
+        """
+        if not all(a.shape[0] == a.shape[1] for a in a_xx):
+            raise ValueError("All arrays in a_xx must be square.")
+
+        if not all(a.shape[0] == a_xx[0].shape[0] for a in a_xx):
+            raise ValueError("All arrays in a_xx must have the same shape.")
+
+        zero_inds_first = xp.where(xp.diff(a_xx[0].indptr) == 0)[0]
+        zero_inds_last = xp.where(xp.diff(a_xx[-1].indptr) == 0)[0]
+        offset = a_xx[0].shape[1] * (len(a_xx) - 2)
+
+        zero_inds = xp.concatenate((zero_inds_first, zero_inds_last + offset))
+        all_inds = xp.arange(a_xx[0].shape[1] * (len(a_xx) - 1))
+        nonzero_inds = xp.setdiff1d(all_inds, zero_inds)
+
+        if len(zero_inds) == 0:
+            # No columns are zero, reduction will have no effect.
+            return None, None, None
+
+        return zero_inds, nonzero_inds, xp.concatenate((nonzero_inds, zero_inds))
 
     def __call__(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
         """Solves the polynomial eigenvalue problem through linearization.
@@ -134,6 +140,22 @@ class Full(NEVP):
         batch_shape = a_xx[0].shape[:-2]
         if a_xx[0].ndim > 3:
             a_xx = tuple(a_x.reshape(-1, *a_x.shape[-2:]) for a_x in a_xx)
+
+        if self.reduce and not hasattr(self, "zero_indices"):
+            # Identify zero columns at runtime if not provided at instantiation.
+            self.zero_indices, self.nonzero_indices, self.all_indices = (
+                self._find_zero_columns(
+                    tuple(sparse.csc_matrix(a_x[0]) for a_x in a_xx)
+                )
+            )
+
+            if self.zero_indices is None:
+                # No columns are zero.
+                warnings.warn(
+                    "No columns are zero in the first and last blocks. "
+                    "Reduction has no effect.",
+                )
+                self.reduce = False
 
         inverse = linalg.inv(sum(a_xx))
 

--- a/src/quatrex/core/subsystem.py
+++ b/src/quatrex/core/subsystem.py
@@ -89,6 +89,7 @@ class SubsystemSolver(ABC):
         if obc_config.nevp_solver == "full":
             return Full(
                 eig_compute_location=nevp_config.eig_compute_location,
+                use_pinned_memory=nevp_config.use_pinned_memory,
                 reduce=nevp_config.reduce_sparsity,
             )
 

--- a/src/quatrex/device/contact.py
+++ b/src/quatrex/device/contact.py
@@ -762,30 +762,26 @@ class Contact:
             )
         if obc_config.nevp_solver == "full":
 
-            a_sparsity = None
+            a_xx = None
             if nevp_config.reduce_sparsity:
+                # For QTBM, we can precompute the sparsity pattern of
+                # the matrix polynomial coefficients here.
 
-                a_sparsity = [
-                    xp.zeros_like(self.unit_cell_hamiltonian[0, 0, 0].toarray())
-                    for _ in range(2 * self.num_transport_cells + 1)
-                ]
+                a_xx = [None] * (2 * self.num_transport_cells + 1)
+                for r, h_r in self.unit_cell_hamiltonian.items():
+                    s_r = self.unit_cell_overlap.get(r, 0)
+                    a_r = sparse.csc_matrix(s_r + h_r)
 
-                for key, values in self.unit_cell_hamiltonian.items():
-                    values = values.toarray()
-                    a_sparsity[self.num_transport_cells + key[0]] += values != 0
-                    a_sparsity[self.num_transport_cells - key[0]] += values.T != 0
+                    a_xx[self.num_transport_cells + r[0]] = a_r
+                    a_xx[self.num_transport_cells - r[0]] = a_r.T
 
-                for key, values in self.unit_cell_overlap.items():
-                    values = values.toarray()
-                    a_sparsity[self.num_transport_cells + key[0]] += values != 0
-                    a_sparsity[self.num_transport_cells - key[0]] += values.T != 0
-
-                a_sparsity = tuple(a_sparsity)
+                a_xx = tuple(a_xx)
 
             return Full(
                 eig_compute_location=nevp_config.eig_compute_location,
-                a_sparsity=a_sparsity,
+                use_pinned_memory=nevp_config.use_pinned_memory,
                 reduce=nevp_config.reduce_sparsity,
+                a_xx_sparsity=a_xx,
             )
 
         raise NotImplementedError(

--- a/tests/qttools/boundary_conditions/obc/test_nevp.py
+++ b/tests/qttools/boundary_conditions/obc/test_nevp.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from qttools import NDArray, xp
+from qttools import NDArray, sparse, xp
 from qttools.nevp import NEVP, Full
 
 
@@ -39,8 +39,9 @@ def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
 
 
 @pytest.mark.parametrize("reduce", [False, True])
-def test_full(a_xx: tuple[NDArray, ...], reduce: bool):
-    """Tests that the subspace NEVP solver returns the correct result."""
+@pytest.mark.parametrize("provide_sparsity", [False, True])
+def test_full(a_xx: tuple[NDArray, ...], reduce: bool, provide_sparsity: bool):
+    """Tests that the full NEVP solver returns the correct result."""
 
     a_xx = tuple(a_x.copy() for a_x in a_xx)
 
@@ -50,12 +51,14 @@ def test_full(a_xx: tuple[NDArray, ...], reduce: bool):
         a_xx[0][..., : size // 2] = 0
         a_xx[2][..., size // 2 :] = 0
 
-    a_sparsity = tuple((a != 0).astype(xp.float32) for a in a_xx)
+    a_xx_sparsity = None
+    if provide_sparsity:
+        if len(a_xx[0].shape) > 2:
+            a_xx_sparsity = tuple(sparse.csc_matrix(a_x[0]) for a_x in a_xx)
+        else:
+            a_xx_sparsity = tuple(sparse.csc_matrix(a) for a in a_xx)
 
-    if len(a_xx[0].shape) > 2:
-        a_sparsity = tuple(xp.sum(a, axis=0) for a in a_sparsity)
-
-    full_nevp = Full(a_sparsity=a_sparsity, reduce=reduce)
+    full_nevp = Full(a_xx_sparsity=a_xx_sparsity, reduce=reduce)
     ws, vs = full_nevp(a_xx)
 
     a_ji, a_ii, a_ij = a_xx


### PR DESCRIPTION
Now we pass in tuples of sparse matrices, from which the sparsity pattern of the matrix A is inferred.

If the coefficient block sparsity patterns cannot be given at instantiation (this is the case in how SCBA is currently coded) the reduced sparsity can be computed at the first call.

Adjusted tests and exposed the functionality in SCBA and QTBM.