### PR TITLE
Fix Meir-Wingreen current computations in RGF

### DIFF
--- a/examples/w90/carbon-nanotube/gw-dist/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/gw-dist/quatrex_config.toml
@@ -21,7 +21,6 @@ symmetric = true
 
 [outputs] # Select which outputs to write.
 electron_ldos = true
-contact_currents = true
 device_currents = true
 electron_density = false
 hole_density = false

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_device_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_device_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91fd30267f10147aaa26a400b5628707aebb58350bb781071eefc4939edadb53
-size 36928

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_device_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_device_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:104efe27cb6779009fdf347aefb7a04ca1c9273cd447b4b2f22980f66ecf26d7
-size 36928

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_left_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_left_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c5444feb326a7a41cfb273a5f5d0cd7870c180ddd74ed137f2a2f0102be4908
-size 1728

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_left_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_left_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15d519519848a60e11a7070d4204bf84ca97f1d4e2f702cc5427cb1a180f2979
-size 1728

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_right_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_right_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84927ac0d4721a0439c140c3e2a6e2f758a7c8db471015b1f159cfe213874a83
-size 1728

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_right_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/i_right_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57db04e87492d90d06a5fb0fc1fa5e6218bf03f4269d73320614b2c1729e9f50
-size 1728

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/meir_wingreen_current_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/meir_wingreen_current_0.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b77fc45b2ff1549a33eb2b65017da801f42fb3c04ce68d64c83d16d6f8fa3d
+size 40128

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/meir_wingreen_current_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/meir_wingreen_current_1.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aa8fb4715384a8e2abb90a486de089aec8e1b87b1da008feab32792fd9c34ba
+size 40128

--- a/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
@@ -19,7 +19,6 @@ symmetric = true
 
 [outputs] # Select which outputs to write.
 electron_ldos = true
-contact_currents = true
 device_currents = true
 electron_density = true
 hole_density = true

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4066233eef31886823001c4327bed08251898b31937a803ab0553e4c82f8ea2
-size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_device_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a223609f89ea9d736cbeae79ae4b76125ba7f5accd2e588fb73e6aebc8ac210
-size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:122b7ad06ae8f78d6cb55f8fa5bba86c70e62604a27be2c7dcf8c1533613b858
-size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_left_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fa1358f5679c792755493b31cfe7eba80dfbfa6709df84996a64c85e64e6fa9
-size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e5334f8362c99f0da2817f73b4dac183930d1ed86bcbbb97322c58b55f01156
-size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_meir-wingreen_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63e395e5433364738065aa566a351e50476f5e1f35e6283ea33a34b5d2cee48c
-size 17728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:185616c9b416b591aad5b3bd035a28dc006e2a1e1b2bc2fa9273b06e3edaae15
-size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/i_right_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3da44b0dccdbb61b40275d0ec4703cfc0a08bb03f525d88d06935e547202f803
-size 1728

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_0.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e5334f8362c99f0da2817f73b4dac183930d1ed86bcbbb97322c58b55f01156
-size 17728
+oid sha256:4ccae90bd40741938e9d062fc662a328e2454ae6863b5fea4388c97a0d7ad199
+size 20928

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/meir_wingreen_current_1.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63e395e5433364738065aa566a351e50476f5e1f35e6283ea33a34b5d2cee48c
-size 17728
+oid sha256:dcf8f4749f802b47718b2258c7cb99aafd3b415ad3cb3f8ce353164f43dcba1c
+size 20928

--- a/examples/w90/carbon-nanotube/gw/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/gw/quatrex_config.toml
@@ -18,7 +18,6 @@ symmetric = true
 
 [outputs] # Select which outputs to write.
 electron_ldos = true
-contact_currents = true
 device_currents = true
 electron_density = false
 hole_density = false

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_device_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_device_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e1554a591e2f47ff8cb8ec7cb501fbddc3348c2e332166d6444d3d0a7ab6801
-size 36928

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_device_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_device_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f011a53d283ee906579ea28abf521e34d975a613d81c312bb9ff01959d9d8cc7
-size 36928

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_left_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_left_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52599f3bbfaa448b0eb5adb2cb9b498245bb5480a04332692543df865bd40263
-size 1728

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_left_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_left_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4e19dcd941974925f01b7556d98b937d258792847ee7c6b3d26c966515c1f5b
-size 1728

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_meir-wingreen_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_meir-wingreen_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b63ad2b23134fdcec458e9bb0c1936f7ae32c915dc4e9f362d251f6af0b1dc5c
-size 36928

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_meir-wingreen_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_meir-wingreen_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c22bbfd9b654b2dcc88bfae1cd0cbee9617e17e8ba203dae5fcd3ae0a4bf5753
-size 36928

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_right_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_right_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b6c894d7e6acacbf28bc8dd0b2a22463537f4360f5f26f106b9d2e30e5fe192
-size 1728

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/i_right_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/i_right_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c51e03a8b9baec762e09ce56aa98f5d6ebd2ba41e85a32608bd85e78ee0e2805
-size 1728

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/meir_wingreen_current_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/meir_wingreen_current_0.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b63ad2b23134fdcec458e9bb0c1936f7ae32c915dc4e9f362d251f6af0b1dc5c
-size 36928
+oid sha256:cf08495ecd21a9ecfd92e15748d50633b27d1a9dce7f108a870c33a45ca71a64
+size 40128

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/meir_wingreen_current_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/meir_wingreen_current_1.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c22bbfd9b654b2dcc88bfae1cd0cbee9617e17e8ba203dae5fcd3ae0a4bf5753
-size 36928
+oid sha256:38d32450298ab703c45f4f1c2e5977beab7917139f66450f85c6cdb8af780985
+size 40128

--- a/examples/w90/carbon-nanotube/qtbm/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/qtbm/quatrex_config.toml
@@ -25,15 +25,6 @@ num_orbitals_per_atom = { "X" = 1 }
 [qtbm] # ===============================================================
 max_batch_size = 1
 
-
-[outputs] # Select which outputs to write.
-electron_ldos = true
-contact_currents = true
-device_currents = true
-electron_density = true
-hole_density = true
-
-
 [electron] # ===========================================================
 # 0.2 V Potential difference.
 left_fermi_level = -3.6  # eV

--- a/examples/w90/mos2/gw-kpoints/quatrex_config.toml
+++ b/examples/w90/mos2/gw-kpoints/quatrex_config.toml
@@ -23,7 +23,6 @@ align_self_energy_to_complex_axes = false
 
 [outputs]  # Select which outputs to write.
 electron_ldos = true
-contact_currents = true
 device_currents = true
 electron_density = true
 hole_density = true

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/meir_wingreen_current_0.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/meir_wingreen_current_0.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9526390cadd8b74c07a17533c462abba655b7112d9c6f34348041e029d40ee4f
-size 14528
+oid sha256:f22ff5c02cb080040e1ea47d408a4f8e80f68b5a6c28c83b89be8b45352f7618
+size 24128

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/meir_wingreen_current_1.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/meir_wingreen_current_1.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c75d6c5e8f3d7b4c49602c0ecdf73be585e82a1f0942a3e2c48021e6ef1b0da
-size 14528
+oid sha256:c8cfca87eab0dd0e26809dbaa6ca70d119f66792ad85989124aa010d5fa289ee
+size 24128

--- a/src/qttools/greens_function_solver/rgf.py
+++ b/src/qttools/greens_function_solver/rgf.py
@@ -172,8 +172,10 @@ class RGF(GFSolver):
             obc_blocks = OBCBlocks(num_blocks=a.num_blocks)
 
         if return_current:
-            # Allocate a buffer for the current.
-            current = xp.zeros((*a.shape[:-2], a.num_blocks - 1), dtype=a.dtype)
+            # Allocate a buffer for the current. This includes current
+            # between each layer and from/to the leads (in total
+            # num_blocks + 1).
+            current = xp.zeros((*a.shape[:-2], a.num_blocks + 1), dtype=a.dtype)
 
         # Get list of batches to perform
         batches_sizes, batches_slices = get_batches(a.shape[0], self.max_batch_size)
@@ -379,6 +381,7 @@ class RGF(GFSolver):
                 )
 
                 if return_current:
+                    a_ji_dagger = a_ji.conj().swapaxes(-2, -1)
                     a_ji_xr_ii = a_ji @ xr_ii
                     a_ji_xr_ii_sx_ij = a_ji_xr_ii @ sigma_lesser_ij
                     sigma_lesser_tilde = (
@@ -392,7 +395,7 @@ class RGF(GFSolver):
                         + a_ji_xr_ii_sx_ij.conj().swapaxes(-2, -1)
                         - a_ji_xr_ii_sx_ij
                     )
-                    current[stack_slice, ..., i] = xp.trace(
+                    current[stack_slice, ..., j] = xp.trace(
                         sigma_greater_tilde @ xl_diag_blocks[j]
                         - xg_diag_blocks[j] @ sigma_lesser_tilde,
                         axis1=-2,
@@ -402,6 +405,22 @@ class RGF(GFSolver):
                 xr_diag_blocks[i] = xr_ii + xr_ii_a_ij_xr_jj_a_ji @ xr_ii
                 if return_retarded:
                     xr_.blocks[i, i] = xr_diag_blocks[i]
+
+        if return_current:
+            current[..., 0] = xp.trace(
+                obc_blocks.greater[0] @ xl_diag_blocks[0]
+                - xg_diag_blocks[0] @ obc_blocks.lesser[0],
+                axis1=-2,
+                axis2=-1,
+            )
+            # NOTE: Negative sign is needed to get the current flowing
+            # in the correct direction (positive from left to right).
+            current[..., -1] = -xp.trace(
+                obc_blocks.greater[-1] @ xl_diag_blocks[-1]
+                - xg_diag_blocks[-1] @ obc_blocks.lesser[-1],
+                axis1=-2,
+                axis2=-1,
+            )
 
         if out is None:
             if return_retarded:

--- a/src/qttools/greens_function_solver/rgf_dist.py
+++ b/src/qttools/greens_function_solver/rgf_dist.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from qttools import NDArray
+from qttools import NDArray, xp
 from qttools.comm import comm
 from qttools.datastructures.dsdbsparse import DSDBSparse
 from qttools.greens_function_solver import _serinv
@@ -139,6 +139,7 @@ class RGFDist(GFSolver):
         out: tuple[DSDBSparse, ...],
         obc_blocks: OBCBlocks | None = None,
         return_retarded: bool = False,
+        return_current: bool = False,
     ):
         r"""Performs selected inversion of a block-tridiagonal matrix.
 
@@ -163,6 +164,11 @@ class RGFDist(GFSolver):
         return_retarded : bool, optional
             Wether the retarded Green's function should be returned
             along with lesser and greater, by default False
+        return_current : bool, optional
+            Whether to compute and return the current for each layer via
+            the Meir-Wingreen formula. By default False. Note that this
+            is currently only partially supported, and only the boundary
+            currents are computed correctly.
 
         """
 
@@ -185,6 +191,16 @@ class RGFDist(GFSolver):
 
             if obc_blocks is None:
                 obc_blocks = OBCBlocks(num_blocks=a.num_local_blocks)
+
+            if return_current:
+                # Allocate a buffer for the current. This includes current
+                # between each layer and from/to the leads (in total
+                # num_blocks + 1).
+                current = xp.zeros((*a.shape[:-2], a.num_blocks + 1), dtype=a.dtype)
+                # TODO: Only boundary currents are currently supported.
+                # Invalidate the remaining layers by setting them to
+                # xp.nan.
+                current[..., 1:-1] = xp.nan
 
             xl_out, xg_out, *xr_out = out
             if return_retarded:
@@ -382,3 +398,28 @@ class RGFDist(GFSolver):
                     selected_solve=True,
                     return_retarded=return_retarded,
                 )
+
+        if return_current:
+            if comm.block.rank == 0:
+                current[..., 0] = xp.trace(
+                    obc_blocks.greater[0] @ xl_diag_blocks[0]
+                    - xg_diag_blocks[0] @ obc_blocks.lesser[0],
+                    axis1=-2,
+                    axis2=-1,
+                )
+            if comm.block.rank == comm.block.size - 1:
+                # NOTE: Negative sign is needed to get the current flowing
+                # in the correct direction (positive from left to right).
+                current[..., -1] = -xp.trace(
+                    obc_blocks.greater[-1] @ xl_diag_blocks[-1]
+                    - xg_diag_blocks[-1] @ obc_blocks.lesser[-1],
+                    axis1=-2,
+                    axis2=-1,
+                )
+
+            # Now we need to allreduce the current across the block
+            # communicator to get the total current for each layer.
+            total_current = xp.empty_like(current)
+            comm.block.all_reduce(current, total_current, op="sum")
+
+            return total_current

--- a/src/quatrex/core/config.py
+++ b/src/quatrex/core/config.py
@@ -158,10 +158,42 @@ class SolverConfig(BaseModel):
     # The maximum number of energies per batch.
     max_batch_size: PositiveInt = 100
 
-    # Whether to compute the current via the Meir-Wingreen formula.
-    compute_current: bool = False
+    compute_current: bool | None = None
+    """Whether to compute the current via the Meir-Wingreen formula.
+
+    This is only supported for the `"rgf"` algorithm. If not set, it is
+    automatically determined based on the algorithm. (i.e. `True` for
+    `"rgf"` and `False` for `"inv"`)
+
+    If `True`, the current is computed between each layer and from/to the
+    leads. This way of computing the current is usually preferable as it
+    is independet of any interaction cutoffs, since it is computed from
+    the temporarily densified Green's functions and self-energies.
+
+    !!! note
+        This is parameter is only used in the Electron Solver. The
+        Coulomb screening solver does not compute currents, so this
+        parameter is ignored for the Coulomb screening solver.
+
+    """
 
     direct_solver: Literal["superlu", "mumps", "cudss"] = "superlu"
+
+    @model_validator(mode="after")
+    def set_compute_current(self) -> Self:
+        """Sets the `compute_current` parameter based on the algorithm."""
+        if self.compute_current is None:
+            if self.algorithm == "rgf":
+                self.compute_current = True
+            else:
+                self.compute_current = False
+
+        if self.compute_current and self.algorithm != "rgf":
+            raise ValueError(
+                "Current computation is only supported for the RGF algorithm."
+            )
+
+        return self
 
 
 class OBCConfig(BaseModel):
@@ -657,7 +689,6 @@ class OutputConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     # Only the spectral currents are saved by default.
-    contact_currents: bool = True
     device_currents: bool = True
 
     potential: bool = False

--- a/src/quatrex/core/observables.py
+++ b/src/quatrex/core/observables.py
@@ -5,7 +5,6 @@ from functools import partial
 from qttools import NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures.dsdbsparse import DSDBSparse
-from qttools.greens_function_solver.solver import OBCBlocks
 
 
 def get_block(
@@ -127,68 +126,6 @@ def density(
     )
 
 
-def contact_currents(
-    x_lesser: DSDBSparse, x_greater: DSDBSparse, sigma_obc_blocks: OBCBlocks
-) -> tuple[NDArray, NDArray]:
-    """Computes the contact currents.
-
-    Parameters
-    ----------
-    x_lesser : DSDBSparse
-        The lesser Green's function.
-    x_greater : DSDBSparse
-        The greater Green's function.
-    sigma_obc_blocks : OBCBlocks
-        The OBC self-energy blocks.
-
-
-    Returns
-    -------
-    NDArray
-        The contact currents, gathered across all participating ranks.
-
-    """
-    if comm.block.rank == 0:
-        i_left = xp.trace(
-            sigma_obc_blocks.greater[0] @ x_lesser.blocks[0, 0]
-            - x_greater.blocks[0, 0] @ sigma_obc_blocks.lesser[0],
-            axis1=-2,
-            axis2=-1,
-        )
-    else:
-        i_left = xp.empty(x_lesser.stack_shape, dtype=x_lesser.dtype)
-
-    if comm.block.rank == comm.block.size - 1:
-        n = x_lesser.num_local_blocks - 1
-        i_right = xp.trace(
-            sigma_obc_blocks.greater[-1] @ x_lesser.blocks[n, n]
-            - x_greater.blocks[n, n] @ sigma_obc_blocks.lesser[-1],
-            axis1=-2,
-            axis2=-1,
-        )
-    else:
-        i_right = xp.empty(x_lesser.stack_shape, dtype=x_lesser.dtype)
-
-    comm.block.bcast(i_left, root=0)
-    comm.block.bcast(i_right, root=comm.block.size - 1)
-
-    full_i_left = comm.stack.all_gather_v(
-        i_left,
-        axis=0,
-        mask=x_lesser._stack_padding_mask,
-    )
-    full_i_right = comm.stack.all_gather_v(
-        i_right,
-        axis=0,
-        mask=x_lesser._stack_padding_mask,
-    )
-
-    return (
-        full_i_left,
-        full_i_right,
-    )
-
-
 def device_current(
     x_lesser: DSDBSparse, operator: sparse.spmatrix | DSDBSparse
 ) -> NDArray:
@@ -248,7 +185,7 @@ def current_conservation(
     se_int_lesser: DSDBSparse,
     se_int_greater: DSDBSparse,
 ) -> NDArray:
-    """Checks current conservation.
+    r"""Checks current conservation.
     See eq. (12.34) in H. Haug and A.-P. Jauho,
     "Quantum Kinetics in Transport and Optics of Semiconductors"
 

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -13,12 +13,7 @@ from qttools.profiling import Profiler
 from qttools.utils.gpu_utils import get_host
 from qttools.utils.mpi_utils import distributed_load, get_section_sizes
 from quatrex.core.config import QuatrexConfig
-from quatrex.core.observables import (
-    contact_currents,
-    current_conservation,
-    density,
-    device_current,
-)
+from quatrex.core.observables import current_conservation, density, device_current
 from quatrex.core.utils import compute_num_connected_blocks, compute_sparsity_pattern
 from quatrex.coulomb_screening import CoulombScreeningSolver, PCoulombScreening
 from quatrex.device.inputs import (
@@ -463,11 +458,14 @@ class SCBA:
         max_diff = np.empty_like(local_max_diff)
         global_comm.Allreduce(local_max_diff, max_diff, op=MPI.MAX)
 
-        i_left = xp.real(self.observables.electron_current.get("left", 0.0))
-        i_right = xp.real(self.observables.electron_current.get("right", 0.0))
+        meir_wingreen_current = self.observables.electron_current.get(
+            "meir-wingreen", [0, 0]
+        )
+        i_left = xp.real(meir_wingreen_current[0])
+        i_right = xp.real(meir_wingreen_current[-1])
 
         dE = self.electron_energies[1] - self.electron_energies[0]
-        current_diff = xp.abs(xp.sum(i_left) * dE + xp.sum(i_right) * dE)
+        current_diff = xp.abs(xp.sum(i_left) * dE - xp.sum(i_right) * dE)
 
         current_conservation_abs, current_conservation_rel = current_conservation(
             self.data.g_lesser,
@@ -580,17 +578,6 @@ class SCBA:
                 overlap,
             ) / (2 * xp.pi)
 
-        if self.config.outputs.contact_currents:
-            self.observables.electron_current = dict(
-                zip(
-                    ("left", "right"),
-                    contact_currents(
-                        self.data.g_lesser,
-                        self.data.g_greater,
-                        self.electron_solver.obc_blocks,
-                    ),
-                )
-            )
         if self.config.outputs.device_currents:
             self.observables.electron_current["device"] = device_current(
                 self.data.g_lesser, self.electron_solver.hamiltonian
@@ -667,13 +654,6 @@ class SCBA:
         if self.config.outputs.hole_density:
             outputs[f"hole_density_{iteration}.npy"] = self.observables.hole_density
 
-        if self.config.outputs.contact_currents:
-            outputs.update(
-                {
-                    f"i_{contact}_{iteration}.npy": current
-                    for contact, current in self.observables.electron_current.items()
-                }
-            )
         if self.config.outputs.device_currents:
             outputs[f"device_current_{iteration}.npy"] = (
                 self.observables.electron_current["device"]

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -461,8 +461,8 @@ class SCBA:
         meir_wingreen_current = self.observables.electron_current.get(
             "meir-wingreen", [0, 0]
         )
-        i_left = xp.real(meir_wingreen_current[0])
-        i_right = xp.real(meir_wingreen_current[-1])
+        i_left = xp.real(meir_wingreen_current[..., 0])
+        i_right = xp.real(meir_wingreen_current[..., -1])
 
         dE = self.electron_energies[1] - self.electron_energies[0]
         current_diff = xp.abs(xp.sum(i_left) * dE - xp.sum(i_right) * dE)
@@ -583,10 +583,6 @@ class SCBA:
                 self.data.g_lesser, self.electron_solver.hamiltonian
             )
             if self.config.electron.solver.compute_current:
-                if comm.block.size > 1:
-                    raise NotImplementedError(
-                        "Meir-Wingreen current is not implemented for distributed SCBA."
-                    )
 
                 local_current = self.electron_solver.meir_wingreen_current
                 meir_wingreen_current = comm.stack.all_gather_v(
@@ -659,11 +655,6 @@ class SCBA:
                 self.observables.electron_current["device"]
             )
             if self.config.electron.solver.compute_current:
-                if comm.block.size > 1:
-                    raise NotImplementedError(
-                        "Meir-Wingreen current is not implemented for distributed SCBA."
-                    )
-
                 outputs[f"meir_wingreen_current_{iteration}.npy"] = (
                     self.observables.electron_current["meir-wingreen"]
                 )

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -157,11 +157,6 @@ class ElectronSolver(SubsystemSolver):
         if self.flatband and comm.rank == 0:
             print("Flatband conditions detected", flush=True)
 
-        if config.electron.solver.compute_current and comm.block.size > 1:
-            raise NotImplementedError(
-                "Current computation not implemented in distributed mode."
-            )
-
         self.compute_meir_wingreen_current = config.electron.solver.compute_current
 
         self.dos_peak_limit = config.electron.dos_peak_limit
@@ -520,13 +515,14 @@ class ElectronSolver(SubsystemSolver):
             label="ElectronSolver: Solve", level="default", comm=comm
         ):
             if comm.block.size > 1:
-                self.solver_dist.selected_solve(
+                self.meir_wingreen_current = self.solver_dist.selected_solve(
                     a=self.system_matrix,
                     sigma_lesser=sse_lesser,
                     sigma_greater=sse_greater,
                     obc_blocks=self.obc_blocks,
                     out=out,
                     return_retarded=True,
+                    return_current=self.compute_meir_wingreen_current,
                 )
 
             else:

--- a/tests/quatrex/reference/test_reference.py
+++ b/tests/quatrex/reference/test_reference.py
@@ -107,5 +107,5 @@ def test_distributed(example: tuple[Path, bool], tmp_path: Path):
             reference.shape == test.shape
         ), f"Shape mismatch for '{output_file.name}': {reference.shape} vs {test.shape}"
         assert np.allclose(
-            reference, test, rtol=1e-3, atol=1e-4
+            reference, test, rtol=1e-3, atol=1e-4, equal_nan=True
         ), f"Value mismatch for '{output_file.name}'"


### PR DESCRIPTION
The current buffer returned from RGF now includes the current from and to the contacts at either end, as well as the current at each layer. It is now of size `num_blocks + 1` (before `num_blocks - 1`).

The computation of the Meir-Wingreen current had a bug as well. Fixed that.

The `compute_current` parameter was previously set to `False` by default. It is now set to `True` if `"rgf"` is being used. Only used for electrons.

Contact current computation in the observables is removed. It is better to do it in RGF. The corresponding output files are also gone. Now everything you need is the Meir-Wingreen current.

Contact current difference computation in SCBA also changed to use that instead.

This will close #262 