### PR TITLE
Reduce workflow runs

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,7 +1,12 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the quatrex package.
 name: Run Pre-Commit and Determine Code Quality
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
 
 jobs:
   test-linting:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -3,6 +3,7 @@ name: Run Pre-Commit and Determine Code Quality
 
 on:
   pull_request:
+  push:
     branches:
       - dev
       - main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,12 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the quatrex package.
 name: Run Basic Tests and Determine Code Coverage
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
 
 jobs:
   test-cov:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,7 @@ name: Run Basic Tests and Determine Code Coverage
 
 on:
   pull_request:
+  push:
     branches:
       - dev
       - main


### PR DESCRIPTION
Before the workflows were triggered on pull request and on push to all branches. In all PRs the workflows were always run twice.

The idea here is to switch this to only run once per pull request into `main` and `dev`, the `push` trigger is removed for the linting and the tests.