### PR TITLE
Change pytest fixtures to remove autouse parameter where unnecessary

### DIFF
--- a/tests/qttools/boundary_conditions/lyapunov/conftest.py
+++ b/tests/qttools/boundary_conditions/lyapunov/conftest.py
@@ -65,7 +65,7 @@ def inputs(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, slice, sli
     return a, q, row_slice, col_slice
 
 
-@pytest.fixture(params=LYAPUNOV_SOLVERS, autouse=True)
+@pytest.fixture(params=LYAPUNOV_SOLVERS)
 def lyapunov_solver(request: pytest.FixtureRequest) -> LyapunovSolver:
     """Returns a Lyapunov solver."""
     return request.param

--- a/tests/qttools/boundary_conditions/obc/conftest.py
+++ b/tests/qttools/boundary_conditions/obc/conftest.py
@@ -64,7 +64,7 @@ def batch_size(request: pytest.FixtureRequest) -> int:
     return request.param
 
 
-@pytest.fixture(params=ENERGIES, autouse=True, scope="session")
+@pytest.fixture(params=ENERGIES, scope="session")
 def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
     """Returns some boundary blocks for the carbon nanotube example."""
 

--- a/tests/qttools/boundary_conditions/obc/test_nevp.py
+++ b/tests/qttools/boundary_conditions/obc/test_nevp.py
@@ -7,7 +7,6 @@ from qttools import NDArray, sparse, xp
 from qttools.nevp import NEVP, Full
 
 
-@pytest.mark.usefixtures("nevp")
 def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
     """Tests that the subspace NEVP solver returns the correct result."""
     ws, vs = nevp(a_xx)

--- a/tests/qttools/boundary_conditions/obc/test_spectral.py
+++ b/tests/qttools/boundary_conditions/obc/test_spectral.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
-import pytest
 
 from qttools import NDArray, xp
 from qttools.boundary_conditions.obc import OBCSystem, Spectral
@@ -69,10 +68,6 @@ def _make_periodic(
     return a_ji_hat, a_ii_hat, a_ij_hat
 
 
-@pytest.mark.usefixtures(
-    "nevp",
-    "block_sections",
-)
 def test_correctness(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,
@@ -97,10 +92,6 @@ def test_correctness(
     )
 
 
-@pytest.mark.usefixtures(
-    "nevp",
-    "block_sections",
-)
 def test_correctness_batch(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,
@@ -126,10 +117,6 @@ def test_correctness_batch(
     )
 
 
-@pytest.mark.usefixtures(
-    "nevp",
-    "block_sections",
-)
 def test_memoizer(
     a_xx: tuple[NDArray, ...], nevp: NEVP, block_sections: int, memoization_mode: str
 ):
@@ -178,12 +165,6 @@ def test_memoizer(
     )
 
 
-@pytest.mark.usefixtures(
-    "block_size",
-    "batch_size",
-    "nevp",
-    "block_sections",
-)
 def test_upscaling(
     block_size: int,
     batch_size: int,
@@ -217,9 +198,6 @@ def test_upscaling(
     assert xp.allclose(vs_upscaled, vs_upscaled_ref)
 
 
-@pytest.mark.usefixtures(
-    "nevp",
-)
 def test_compute_dE_dk(
     a_xx: tuple[NDArray, ...],
     nevp: NEVP,

--- a/tests/qttools/convolutions/test_convolutions.py
+++ b/tests/qttools/convolutions/test_convolutions.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
 import numpy as np
-import pytest
 
 from qttools import NDArray, xp
 from qttools.fft import (
@@ -201,7 +200,6 @@ class TestNaiveConvolutions:
 
 
 class TestFFTConvolutions:
-    @pytest.mark.usefixtures("array_shape")
     def test_fft_convolve(self, array_shape):
         a = xp.random.random(array_shape)
         b = xp.random.random(array_shape)
@@ -210,7 +208,6 @@ class TestFFTConvolutions:
         expected = _naive_convolve(a, b)
         assert xp.allclose(result, expected)
 
-    @pytest.mark.usefixtures("array_shape")
     def test_fft_circular_convolve(self, array_shape):
         a = xp.random.random(array_shape)
         b = xp.random.random(array_shape)
@@ -226,7 +223,6 @@ class TestFFTConvolutions:
         expected = naive_circular_convolve(a, b, axes)
         assert xp.allclose(result, expected)
 
-    @pytest.mark.usefixtures("array_shape")
     def test_fft_convolve_kpoints(self, array_shape):
         a = xp.random.random(array_shape)
         b = xp.random.random(array_shape)
@@ -235,7 +231,6 @@ class TestFFTConvolutions:
         expected = naive_convolve_kpoints(a, b)
         assert xp.allclose(result, expected)
 
-    @pytest.mark.usefixtures("array_shape")
     def test_fft_correlate_kpoints(self, array_shape):
         a = xp.random.random(array_shape)
         b = xp.random.random(array_shape)

--- a/tests/qttools/datastructures/test_dsdbsparse.py
+++ b/tests/qttools/datastructures/test_dsdbsparse.py
@@ -142,7 +142,6 @@ def _get_block_inds(block: tuple, block_sizes: NDArray) -> tuple:
 class TestAccess:
     """Tests for the access methods of DSDBSparse."""
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_getitem(
         self,
         dsdbsparse_type: DSDBSparse,
@@ -163,7 +162,6 @@ class TestAccess:
         reference = dense[..., *accessed_element]
         assert xp.allclose(reference, dsdbsparse[accessed_element])
 
-    @pytest.mark.usefixtures("num_inds")
     def test_getitem_with_array(
         self,
         dsdbsparse_type: DSDBSparse,
@@ -192,7 +190,6 @@ class TestAccess:
         )
         assert xp.allclose(reference, dsdbsparse[rows, cols])
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_setitem(
         self,
         dsdbsparse_type: DSDBSparse,
@@ -730,7 +727,7 @@ class TestArithmetic:
 ARRAY_SHAPE = (12, 10, 30)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def array() -> NDArray:
     """Returns a random dense array."""
     return xp.random.rand(*ARRAY_SHAPE)

--- a/tests/qttools/datastructures/test_dsdbsparse_dist.py
+++ b/tests/qttools/datastructures/test_dsdbsparse_dist.py
@@ -279,7 +279,6 @@ def _get_block_inds(block: tuple, block_sizes: NDArray) -> tuple:
 class TestAccess:
     """Tests for the access methods of DSDBSparse."""
 
-    @pytest.mark.usefixtures("accessed_block")
     def test_get_block(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -319,7 +318,6 @@ class TestAccess:
                 # Find the correct rank in block-comm
                 assert xp.allclose(reference_block, dsdbsparse.blocks[accessed_block])
 
-    @pytest.mark.usefixtures("accessed_block")
     def test_get_sparse_block(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -385,7 +383,6 @@ class TestAccess:
                 else:
                     raise ValueError("Unknown DSDBSparse type.")
 
-    @pytest.mark.usefixtures("accessed_block")
     def test_set_block(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -448,7 +445,6 @@ class TestAccess:
 
         assert xp.allclose(dense, dsdbsparse.to_dense())
 
-    @pytest.mark.usefixtures("accessed_block", "stack_index")
     def test_get_block_substack(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -502,7 +498,6 @@ class TestAccess:
                     dsdbsparse.stack[stack_index].blocks[accessed_block],
                 )
 
-    @pytest.mark.usefixtures("accessed_block", "stack_index")
     def test_get_sparse_block_substack(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -572,7 +567,6 @@ class TestAccess:
                 else:
                     raise ValueError("Unknown DSDBSparse type.")
 
-    @pytest.mark.usefixtures("accessed_block", "stack_index")
     def test_set_block_substack(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -654,7 +648,6 @@ class TestAccess:
 
         assert xp.allclose(dense, dsdbsparse.to_dense())
 
-    @pytest.mark.usefixtures("block_change_factor")
     def test_block_sizes_setter(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -786,7 +779,6 @@ class TestDistribution:
 
         assert xp.allclose(original_data, dsdbsparse._data)
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_getitem_stack(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -810,7 +802,6 @@ class TestDistribution:
         # is on a different rank in the comm.block.
         assert xp.allclose(reference, test) or (test == 0).all()
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_getitem_nnz(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -836,7 +827,6 @@ class TestDistribution:
         # is on a different rank in the comm.block.
         assert xp.allclose(reference, test) or (test == 0).all()
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_setitem_stack(
         self,
         dsdbsparse_type_dist: DSDBSparse,
@@ -875,7 +865,6 @@ class TestDistribution:
 
         assert xp.allclose(dense, dsdbsparse.to_dense())
 
-    @pytest.mark.usefixtures("accessed_element")
     def test_setitem_nnz(
         self,
         dsdbsparse_type_dist: DSDBSparse,

--- a/tests/qttools/greens_function_solver/conftest.py
+++ b/tests/qttools/greens_function_solver/conftest.py
@@ -40,17 +40,17 @@ GLOBAL_STACK_SHAPES = [
 ]
 
 
-@pytest.fixture(params=BLOCK_SIZES, autouse=True)
+@pytest.fixture(params=BLOCK_SIZES)
 def block_sizes(request: pytest.FixtureRequest) -> NDArray:
     return request.param
 
 
-@pytest.fixture(params=GFSOLVERS_TYPE, autouse=True)
+@pytest.fixture(params=GFSOLVERS_TYPE)
 def gfsolver_type(request: pytest.FixtureRequest) -> GFSolver:
     return request.param
 
 
-@pytest.fixture(params=DSBSPARSE_TYPES, autouse=True)
+@pytest.fixture(params=DSBSPARSE_TYPES)
 def dsdbsparse_type(request: pytest.FixtureRequest) -> DSDBSparse:
     return request.param
 
@@ -62,7 +62,7 @@ def _random_block(m: int, n: int) -> NDArray:
     return coo.toarray()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture(scope="function")
 def bt_dense(block_sizes: NDArray) -> NDArray:
     """Generates a random block-tridiagonal matrix."""
     block_offsets = xp.hstack(([0], xp.cumsum(xp.asarray(block_sizes))))
@@ -104,21 +104,21 @@ def bt_dense(block_sizes: NDArray) -> NDArray:
     return arr
 
 
-@pytest.fixture(params=BATCHING_TYPE, autouse=True)
+@pytest.fixture(params=BATCHING_TYPE)
 def max_batch_size(request: pytest.FixtureRequest) -> int:
     return request.param
 
 
-@pytest.fixture(params=OUT, autouse=True)
+@pytest.fixture(params=OUT)
 def out(request: pytest.FixtureRequest) -> bool:
     return request.param
 
 
-@pytest.fixture(params=RETURN_RETARDED, autouse=True)
+@pytest.fixture(params=RETURN_RETARDED)
 def return_retarded(request: pytest.FixtureRequest) -> bool:
     return request.param
 
 
-@pytest.fixture(params=GLOBAL_STACK_SHAPES, autouse=True)
+@pytest.fixture(params=GLOBAL_STACK_SHAPES)
 def global_stack_shape(request: pytest.FixtureRequest) -> tuple:
     return request.param

--- a/tests/qttools/kernels/datastructure/test_dsdbcoo.py
+++ b/tests/qttools/kernels/datastructure/test_dsdbcoo.py
@@ -94,7 +94,6 @@ def _reference_compute_block_slice(rows, cols, block_offsets, row, col):
     return inds[0], inds[-1] + 1
 
 
-@pytest.mark.usefixtures("shape", "num_inds")
 def test_find_inds(shape: tuple[int, int], num_inds: int):
     """Tests that the indices are found correctly."""
     coo = sparse.random(*shape, density=0.25, format="coo")
@@ -113,7 +112,6 @@ def test_find_inds(shape: tuple[int, int], num_inds: int):
     assert xp.all(value_inds == reference_value_inds)
 
 
-@pytest.mark.usefixtures("shape", "num_blocks", "block_coords")
 def test_compute_block_slice(
     shape: tuple[int, int], num_blocks: int, block_coords: tuple[int, int]
 ):
@@ -139,7 +137,6 @@ def test_compute_block_slice(
     assert block_slice == reference_block_slice
 
 
-@pytest.mark.usefixtures("shape")
 @pytest.mark.parametrize("use_kernel", [True, False])
 def test_densify_block(shape: tuple[int, int], use_kernel: bool):
     """Tests that the block gets densified correctly."""
@@ -168,7 +165,6 @@ def test_densify_block(shape: tuple[int, int], use_kernel: bool):
     assert xp.allclose(block, reference_block)
 
 
-@pytest.mark.usefixtures("shape")
 def test_sparsify_block(shape: tuple[int, int]):
     """Tests that the block gets sparsified correctly."""
     coo = sparse.random(*shape, density=0.25, format="coo")
@@ -180,7 +176,6 @@ def test_sparsify_block(shape: tuple[int, int]):
     assert xp.allclose(data, coo.data)
 
 
-@pytest.mark.usefixtures("shape", "num_blocks")
 def test_compute_block_sort_index(shape: tuple[int, int], num_blocks: int):
     """Tests that the block sort is computed correctly."""
     coo = sparse.random(*shape, density=0.25, format="coo")

--- a/tests/qttools/kernels/datastructure/test_dsdbcsr.py
+++ b/tests/qttools/kernels/datastructure/test_dsdbcsr.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
 import numpy as np
-import pytest
 
 from qttools import NDArray, sparse, xp
 from qttools.kernels.datastructure import dsdbcsr_kernels
@@ -120,7 +119,6 @@ def _reference_find_inds(
     return xp.array(inds, dtype=int), xp.array(value_inds, dtype=int)
 
 
-@pytest.mark.usefixtures("shape", "num_inds", "num_blocks")
 def test_find_inds(shape: tuple[int, int], num_inds: int, num_blocks: int):
     """Tests the that we find the correct indices."""
     coo = sparse.random(*shape, density=0.25, format="coo")
@@ -149,7 +147,6 @@ def test_find_inds(shape: tuple[int, int], num_inds: int, num_blocks: int):
     assert xp.all(value_inds == reference_value_inds)
 
 
-@pytest.mark.usefixtures("shape")
 def test_densify_block(shape: tuple[int, int]):
     """Tests that the block is densified correctly."""
     csr = sparse.random(*shape, density=0.25, format="csr")
@@ -162,7 +159,6 @@ def test_densify_block(shape: tuple[int, int]):
     assert xp.allclose(block, reference_block)
 
 
-@pytest.mark.usefixtures("shape")
 def test_sparsify_block(shape: tuple[int, int]):
     """Tests that the block is sparsified correctly."""
     csr = sparse.random(*shape, density=0.25, format="csr")
@@ -173,7 +169,6 @@ def test_sparsify_block(shape: tuple[int, int]):
     assert xp.allclose(data, csr.data)
 
 
-@pytest.mark.usefixtures("shape", "num_blocks")
 def test_compute_rowptr_map(shape: tuple[int, int], num_blocks: int):
     """Tests that the row pointer map is computed correctly."""
     coo = sparse.random(*shape, density=0.25, format="coo")

--- a/tests/qttools/kernels/datastructure/test_dsdbsparse.py
+++ b/tests/qttools/kernels/datastructure/test_dsdbsparse.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
-import pytest
 
 from qttools import xp
 from qttools.kernels.datastructure import dsdbsparse_kernels
 from qttools.utils.mpi_utils import get_section_sizes
 
 
-@pytest.mark.usefixtures("nnz", "comm_size", "num_inds")
 def test_find_ranks(nnz: int, comm_size: int, num_inds: int):
     """Tests that the ranks are computed correctly."""
     section_sizes, __ = get_section_sizes(nnz, comm_size, strategy="greedy")

--- a/tests/qttools/kernels/linalg/test_eig.py
+++ b/tests/qttools/kernels/linalg/test_eig.py
@@ -12,7 +12,6 @@ if xp.__name__ == "cupy":
     import cupy as cp
 
 
-@pytest.mark.usefixtures("n", "batch_shape")
 def test_eig_numba_ndarray(n: int, batch_shape: tuple[int, ...]):
     """Tests the _eig_numba function with array input."""
 
@@ -32,7 +31,6 @@ def test_eig_numba_ndarray(n: int, batch_shape: tuple[int, ...]):
             assert xp.allclose(A[b] @ v[b][:, i], w[b][i] * v[b][:, i])
 
 
-@pytest.mark.usefixtures("n", "batch_shape")
 def test_eig_numba_list(n: int, batch_shape: tuple[int, ...]):
     """Tests the _eig_numba function with array input."""
 
@@ -62,9 +60,6 @@ def test_eig_numba_list(n: int, batch_shape: tuple[int, ...]):
             assert xp.allclose(A[b] @ v[b][:, i], w[b][i] * v[b][:, i])
 
 
-@pytest.mark.usefixtures(
-    "n", "eig_compute_module", "input_module", "output_module", "use_pinned_memory"
-)
 @pytest.mark.parametrize("if_list", [False, True])
 def test_eig(
     n: int,
@@ -122,14 +117,6 @@ def test_eig(
         assert xp.allclose(A @ v[:, i], w[i] * v[:, i])
 
 
-@pytest.mark.usefixtures(
-    "n",
-    "batch_shape",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 @pytest.mark.parametrize("if_list", [False, True])
 def test_eig_batched(
     n: int,

--- a/tests/qttools/kernels/linalg/test_eigvalsh.py
+++ b/tests/qttools/kernels/linalg/test_eigvalsh.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 import numpy as np
-import pytest
 import scipy
 
 from qttools import xp
@@ -8,9 +7,6 @@ from qttools.kernels import linalg
 from qttools.utils.gpu_utils import get_device, get_host
 
 
-@pytest.mark.usefixtures(
-    "n", "compute_module", "input_module", "output_module", "use_pinned_memory"
-)
 def test_eigvalsh(
     n: int,
     compute_module: str,
@@ -53,14 +49,6 @@ def test_eigvalsh(
     assert xp.allclose(w, w_ref)
 
 
-@pytest.mark.usefixtures(
-    "n",
-    "batch_shape",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 def test_eigvalsh_batched(
     n: int,
     batch_shape: tuple[int, ...],
@@ -107,7 +95,6 @@ def test_eigvalsh_batched(
     assert xp.allclose(w, w_ref)
 
 
-@pytest.mark.usefixtures("n", "compute_module", "input_module", "output_module")
 def test_eigvalsh_generalized(
     n: int,
     compute_module: str,
@@ -156,14 +143,6 @@ def test_eigvalsh_generalized(
     assert xp.allclose(w, w_ref)
 
 
-@pytest.mark.usefixtures(
-    "n",
-    "batch_shape",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 def test_eigvalsh_generalized_batched(
     n: int,
     batch_shape: tuple[int, ...],

--- a/tests/qttools/kernels/linalg/test_qr.py
+++ b/tests/qttools/kernels/linalg/test_qr.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 import numpy as np
-import pytest
 
 from qttools import xp
 from qttools.kernels import linalg
@@ -11,7 +10,6 @@ if xp.__name__ == "cupy":
     import cupy as cp
 
 
-@pytest.mark.usefixtures("m", "n", "batch_shape")
 def test_qr_numba_ndarray(m: int, n: int, batch_shape: tuple[int, ...]):
     """Tests the _qr_numba_ndarray function."""
 
@@ -28,9 +26,6 @@ def test_qr_numba_ndarray(m: int, n: int, batch_shape: tuple[int, ...]):
     assert xp.allclose(A, q @ r)
 
 
-@pytest.mark.usefixtures(
-    "m", "n", "compute_module", "input_module", "output_module", "use_pinned_memory"
-)
 def test_qr(
     m: int,
     n: int,
@@ -68,16 +63,6 @@ def test_qr(
     assert xp.allclose(A, q @ r)
 
 
-@pytest.mark.usefixtures(
-    "m",
-    "n",
-    "batch_shape",
-    "full_matrices",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 def test_qr_batched(
     m: int,
     n: int,

--- a/tests/qttools/kernels/linalg/test_svd.py
+++ b/tests/qttools/kernels/linalg/test_svd.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 import numpy as np
-import pytest
 
 from qttools import xp
 from qttools.kernels import linalg
@@ -11,7 +10,6 @@ if xp.__name__ == "cupy":
     import cupy as cp
 
 
-@pytest.mark.usefixtures("m", "n", "full_matrices", "batch_shape")
 def test_svd_numba_ndarray(
     m: int, n: int, full_matrices: bool, batch_shape: tuple[int, ...]
 ):
@@ -41,15 +39,6 @@ def test_svd_numba_ndarray(
     assert xp.allclose(A, u @ s_dense @ vh)
 
 
-@pytest.mark.usefixtures(
-    "m",
-    "n",
-    "full_matrices",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 def test_svd(
     m: int,
     n: int,
@@ -95,16 +84,6 @@ def test_svd(
     assert xp.allclose(A, u @ np.diag(s) @ vh)
 
 
-@pytest.mark.usefixtures(
-    "m",
-    "n",
-    "batch_shape",
-    "full_matrices",
-    "compute_module",
-    "input_module",
-    "output_module",
-    "use_pinned_memory",
-)
 def test_svd_batched(
     m: int,
     n: int,

--- a/tests/qttools/kernels/test_operator.py
+++ b/tests/qttools/kernels/test_operator.py
@@ -1,17 +1,10 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
-import pytest
 
 from qttools import xp
 from qttools.kernels.operator import operator_inverse
 
 
-@pytest.mark.usefixtures(
-    "batchsize",
-    "n",
-    "num_quatrature_points",
-    "num_blocks",
-)
 def test_operator_inverse(
     batchsize,
     n,

--- a/tests/qttools/utils/test_gpu_utils.py
+++ b/tests/qttools/utils/test_gpu_utils.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
 import numpy as np
-import pytest
 
 from qttools import xp
 from qttools.utils.gpu_utils import (
@@ -14,9 +13,6 @@ from qttools.utils.gpu_utils import (
 )
 
 
-@pytest.mark.usefixtures(
-    "shape", "dtype", "order", "input_module", "output_module", "use_pinned_memory"
-)
 def test_get_any_location(
     shape: int | tuple[int, ...],
     dtype: type | str,
@@ -64,7 +60,6 @@ def test_get_any_location(
     assert np.allclose(out, arr)
 
 
-@pytest.mark.usefixtures("shape", "dtype", "order")
 def test_empty_pinned(
     shape: int | tuple[int, ...],
     dtype: type | str,
@@ -77,7 +72,6 @@ def test_empty_pinned(
     assert arr.flags["C_CONTIGUOUS"] if order == "C" else arr.flags["F_CONTIGUOUS"]
 
 
-@pytest.mark.usefixtures("shape", "dtype", "order")
 def test_zeros_pinned(
     shape: int | tuple[int, ...],
     dtype: type | str,
@@ -91,7 +85,6 @@ def test_zeros_pinned(
     assert xp.allclose(arr, np.zeros(shape, dtype=dtype))
 
 
-@pytest.mark.usefixtures("shape", "dtype", "order")
 def test_empty_like_pinned(
     shape: int | tuple[int, ...],
     dtype: type | str,
@@ -109,7 +102,6 @@ def test_empty_like_pinned(
     )
 
 
-@pytest.mark.usefixtures("shape", "dtype", "order")
 def test_zeros_like_pinned(
     shape: int | tuple[int, ...],
     dtype: type | str,

--- a/tests/qttools/wave_function_solver/conftest.py
+++ b/tests/qttools/wave_function_solver/conftest.py
@@ -11,13 +11,13 @@ NUM_RHS = [
 ]
 
 
-@pytest.fixture(params=NUM_ROWS, autouse=True)
+@pytest.fixture(params=NUM_ROWS)
 def n(request: pytest.FixtureRequest) -> int:
     """Fixture to provide the number of rows for the sparse matrix."""
     return request.param
 
 
-@pytest.fixture(params=NUM_RHS, autouse=True)
+@pytest.fixture(params=NUM_RHS)
 def m(request: pytest.FixtureRequest) -> int:
     """Fixture to provide the number of right-hand sides for the solver."""
     return request.param

--- a/tests/quatrex/conftest.py
+++ b/tests/quatrex/conftest.py
@@ -18,7 +18,7 @@ EXAMPLES = [
 ]
 
 
-@pytest.fixture(params=EXAMPLES, autouse=True, scope="function")
+@pytest.fixture(params=EXAMPLES, scope="function")
 def example(request: pytest.FixtureRequest) -> tuple[Path, bool]:
     return request.param
 

--- a/tests/quatrex/coulomb_screening/test_polarization.py
+++ b/tests/quatrex/coulomb_screening/test_polarization.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
-import pytest
 
 from qttools import NDArray, xp
 from qttools.fft.convolve import _naive_convolve
@@ -21,7 +20,6 @@ def naive_hilbert_transform(a: NDArray, energies: NDArray) -> NDArray:
     return result[2 * ne : 3 * ne]
 
 
-@pytest.mark.usefixtures("array_shape")
 def test_hilbert_transform(array_shape):
     # Use the symmetry of the polarization $a(-\omega)=a^{*}(\omega)$
     ne = array_shape[0]

--- a/tests/quatrex/device/conftest.py
+++ b/tests/quatrex/device/conftest.py
@@ -12,7 +12,7 @@ EXAMPLES_DIR = Path(__file__).parents[3].resolve() / "examples"
 MOS2_EXAMPLE = EXAMPLES_DIR / "w90" / "mos2" / "inputs"
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(scope="session")
 def unit_cells(request: pytest.FixtureRequest) -> NDArray:
     """Returns the wannier tight binding matrix of the mos2 example"""
 

--- a/tests/quatrex/electron/test_sse_coulomb_screening.py
+++ b/tests/quatrex/electron/test_sse_coulomb_screening.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
-import pytest
 
 from qttools import NDArray, xp
 from qttools.fft.convolve import _naive_convolve
@@ -17,7 +16,6 @@ def naive_hilbert_transform(a_full: NDArray, energies: NDArray) -> NDArray:
     return result[2 * ne : 3 * ne]
 
 
-@pytest.mark.usefixtures("array_shape")
 def test_hilbert_transform(array_shape):
     ne = array_shape[0]
     # Also add orbital dimension at the end


### PR DESCRIPTION
The use of `autouse` caused around 500 duplicate test cases.

Additionally, marking tests to use fixtures is unnecessary, when they already explicitly request a fixture. Just a cosmetic change.