### PR TITLE
Address symmetry issue when not aligning with the complex axis

### DIFF
--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/p_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/p_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43ac6f24230473b3a5fd3e0c7409b19a87383fe812caf6a756868ccf5a187fab
-size 614528

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/p_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/p_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db64b60135453f83627f71d674266db3703e7e26900ad9f880508d8debbd0fd1
-size 614528

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/sigma_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/sigma_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d160e1b6dba13067f313d42efe924e6246be6ebb79cb66713dce8debcdf2c1f5
-size 614528

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/sigma_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/sigma_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a54d860a83aad04a70ba480d7604bbcdfa1e1e405e33f4e2a5383732329963a2
-size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b052dfa446220f9b90844f207220f997f04f48128bea6106f21af06054b02191
-size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/p_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c71adf614292c5a9b552b195f158be0edb94a21a9e76a48b020bdd1f29ac9e34
-size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d160e1b6dba13067f313d42efe924e6246be6ebb79cb66713dce8debcdf2c1f5
-size 614528

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/sigma_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9926d0346e3f413f98f0eb6587e97acd74154ebfb1bf7e7638736ea2a67ee673
-size 614528

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/p_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/p_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3873432c0f242d6a323767a9afcd02cc301256f96d66e3a7ebc15121b3ec7fd3
-size 614528

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/p_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/p_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b5d1ae543f7d65d107667e3b96863de341c00a8f7af4e4a825841df82a775c5
-size 614528

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/sigma_retarded_density_0.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/sigma_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d160e1b6dba13067f313d42efe924e6246be6ebb79cb66713dce8debcdf2c1f5
-size 614528

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/sigma_retarded_density_1.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/sigma_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff814d216d5cd1dedf5b023b7091524860bff17c7e73855273e37e70cf8275eb
-size 614528

--- a/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
+++ b/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
@@ -15,7 +15,7 @@ num_transport_cells = 4
 [scba] # =============================================================
 max_iterations = 2
 mixing_factor = 0.5
-symmetric = false
+symmetric = true
 
 coulomb_screening = true
 phonon = true
@@ -42,7 +42,7 @@ fermi_level = -0.3 # eV
 conduction_band_edge = -0.3187 # eV
 valence_band_edge = -2.0026 # eV
 
-band_edge_tracking = true
+band_edge_tracking = "eigenvalues"
 
 flatband = false
 

--- a/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
+++ b/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
@@ -42,7 +42,7 @@ fermi_level = -0.3 # eV
 conduction_band_edge = -0.3187 # eV
 valence_band_edge = -2.0026 # eV
 
-band_edge_tracking = "eigenvalues"
+band_edge_tracking = true
 
 flatband = false
 

--- a/examples/w90/mos2/gw-kpoints-symmetric/reference-outputs
+++ b/examples/w90/mos2/gw-kpoints-symmetric/reference-outputs
@@ -1,0 +1,1 @@
+../gw-kpoints/reference-outputs/

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/p_retarded_density_0.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/p_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a707a907d224175a4c5619ae4f257f9896dbc3c300b2a68c88712acd9e91da7
-size 422528

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/p_retarded_density_1.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/p_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66630e6e101f89a3e8c03820ba1cc59a65e0bad96a39e4b4dc3a5ac7fc9e6a2f
-size 422528

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/sigma_retarded_density_0.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/sigma_retarded_density_0.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:257a8d12ffbe43129b2f1506f0253a4fcab3c2533396a3861823480e670d855b
-size 422528

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/sigma_retarded_density_1.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/sigma_retarded_density_1.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12ea4ce22fdafbaa6b623701999648abf43b7e6764c36a9bfecc47c6d3bf99a9
-size 422528

--- a/src/quatrex/bandstructure/band_edges.py
+++ b/src/quatrex/bandstructure/band_edges.py
@@ -43,7 +43,9 @@ def _compute_eigenvalues(
     hamiltonian: DSDBSparse,
     overlap: DSDBSparse | None,
     potential: NDArray,
-    sigma_retarded: DSDBSparse,
+    sigma_lesser: DSDBSparse,
+    sigma_greater: DSDBSparse,
+    sigma_retarded_hermitian: DSDBSparse,
     ind: tuple[int, ...],
     diagonal_inds: tuple,
     upper_inds: tuple,
@@ -75,8 +77,12 @@ def _compute_eigenvalues(
         orthogonal.
     potential : NDArray
         The potential.
-    sigma_retarded : DSDBSparse
-        The retarded self-energy.
+    sigma_lesser : DSDBSparse
+        The lesser self-energy.
+    sigma_greater : DSDBSparse
+        The greater self-energy.
+    sigma_retarded_hermitian : DSDBSparse
+        The hermitian part of the retarded self-energy.
     ind : tuple[int, ...]
         The local (E, k) index where the eigenvalues should be computed.
         This is a guess that should be as close as possible to where the
@@ -116,7 +122,7 @@ def _compute_eigenvalues(
     if not use_eigvalsh:
         raise NotImplementedError("Only use_eigvalsh=True is supported.")
 
-    big_blocksize = sigma_retarded.block_sizes[diagonal_inds[0]]
+    big_blocksize = sigma_retarded_hermitian.block_sizes[diagonal_inds[0]]
     small_blocksize = big_blocksize // block_sections
 
     h_slice = (np.s_[:],) + tuple(ind[1:]) + np.s_[:small_blocksize, :]
@@ -134,11 +140,30 @@ def _compute_eigenvalues(
     # Sigma is extract at a certain energy and k-point
     # NOTE: In this case we use only the real part of the retarded
     # self-energy.
+
+    # NOTE: Even if the real part is used, the lesser and greater self-energies
+    # need to be taken into account since they can have a non-zero real part.
     sigma_00 = xp.real(
-        order_block(sigma_retarded.blocks[*diagonal_inds], order)[sigma_slice]
+        order_block(
+            sigma_retarded_hermitian.blocks[*diagonal_inds]
+            + 0.5
+            * (
+                sigma_greater.blocks[*diagonal_inds]
+                - sigma_lesser.blocks[*diagonal_inds]
+            ),
+            order,
+        )[sigma_slice]
     )
     sigma_01 = xp.real(
-        order_block(sigma_retarded.blocks[*upper_inds], order)[sigma_slice]
+        order_block(
+            sigma_retarded_hermitian.blocks[*upper_inds]
+            + 0.5
+            * (
+                sigma_greater.blocks[*diagonal_inds]
+                - sigma_lesser.blocks[*diagonal_inds]
+            ),
+            order,
+        )[sigma_slice]
     )
 
     sigma_00 = _block_view(sigma_00, axis=-1, num_blocks=block_sections)
@@ -217,7 +242,9 @@ def find_renormalized_eigenvalues(
     hamiltonian: DSDBSparse,
     overlap: DSDBSparse | None,
     potential: NDArray,
-    sigma_retarded: DSDBSparse,
+    sigma_lesser: DSDBSparse,
+    sigma_greater: DSDBSparse,
+    sigma_retarded_hermitian: DSDBSparse,
     energies: NDArray,
     conduction_band_guesses: tuple[float, float],
     mid_gap_energies: tuple[float, float],
@@ -237,8 +264,8 @@ def find_renormalized_eigenvalues(
         The lesser self-energy.
     sigma_greater : DSDBSparse
         The greater self-energy.
-    sigma_retarded : DSDBSparse
-        The retarded self-energy.
+    sigma_retarded_hermitian : DSDBSparse
+        The hermitian part of the retarded self-energy.
     energies : NDArray
         The energies.
     local_energies : NDArray
@@ -284,13 +311,15 @@ def find_renormalized_eigenvalues(
                 # is at the Gamma point.
                 # TODO: Generalize this to arbitrary k-points (and maybe change gamma point index).
                 local_ind = (ind_left - section_offsets[rank_left],) + tuple(
-                    [s // 2 for s in sigma_retarded.shape[1:-2]]
+                    [s // 2 for s in sigma_retarded_hermitian.shape[1:-2]]
                 )
                 e_0_left = _compute_eigenvalues(
                     hamiltonian=hamiltonian,
                     overlap=overlap,
                     potential=potential,
-                    sigma_retarded=sigma_retarded,
+                    sigma_lesser=sigma_lesser,
+                    sigma_greater=sigma_greater,
+                    sigma_retarded_hermitian=sigma_retarded_hermitian,
                     ind=local_ind,
                     diagonal_inds=(0, 0),
                     upper_inds=(0, 1),
@@ -323,7 +352,7 @@ def find_renormalized_eigenvalues(
                 # is at the Gamma point.
                 # TODO: Generalize this to arbitrary k-points (and maybe change gamma point index).
                 local_ind = (ind_right - section_offsets[rank_right],) + tuple(
-                    [s // 2 for s in sigma_retarded.shape[1:-2]]
+                    [s // 2 for s in sigma_retarded_hermitian.shape[1:-2]]
                 )
 
                 n = hamiltonian.num_local_blocks - 1
@@ -332,7 +361,9 @@ def find_renormalized_eigenvalues(
                     hamiltonian=hamiltonian,
                     overlap=overlap,
                     potential=potential,
-                    sigma_retarded=sigma_retarded,
+                    sigma_lesser=sigma_lesser,
+                    sigma_greater=sigma_greater,
+                    sigma_retarded_hermitian=sigma_retarded_hermitian,
                     ind=local_ind,
                     diagonal_inds=(n, n),
                     upper_inds=(n, m),

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -119,11 +119,11 @@ class SCBAData:
         self.sigma_greater_prev = dsdbsparse_type.zeros_like(self.g_lesser)
         self.sigma_greater = dsdbsparse_type.zeros_like(self.g_lesser)
 
-        self.sigma_retarded_prev = dsdbsparse_type.zeros_like(self.g_lesser)
-        self.sigma_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_retarded_hermitian_prev = dsdbsparse_type.zeros_like(self.g_lesser)
+        self.sigma_retarded_hermitian = dsdbsparse_type.zeros_like(self.g_lesser)
         if config.scba.symmetric:
-            self.sigma_retarded.symmetry_op = lambda a: a.conj()
-            self.sigma_retarded_prev.symmetry_op = lambda a: a.conj()
+            self.sigma_retarded_hermitian.symmetry_op = lambda a: a.conj()
+            self.sigma_retarded_hermitian_prev.symmetry_op = lambda a: a.conj()
 
         if config.scba.coulomb_screening:
             # NOTE: The polarization has the same sparsity pattern as
@@ -350,9 +350,11 @@ class SCBA:
         """Stash the current into the previous self-energy buffers."""
         self.data.sigma_lesser_prev.data[:] = self.data.sigma_lesser.data
         self.data.sigma_greater_prev.data[:] = self.data.sigma_greater.data
-        self.data.sigma_retarded_prev.data[:] = self.data.sigma_retarded.data
+        self.data.sigma_retarded_hermitian_prev.data[:] = (
+            self.data.sigma_retarded_hermitian.data
+        )
 
-        self.data.sigma_retarded.data[:] = 0.0
+        self.data.sigma_retarded_hermitian.data[:] = 0.0
         self.data.sigma_lesser.data[:] = 0.0
         self.data.sigma_greater.data[:] = 0.0
 
@@ -365,14 +367,14 @@ class SCBA:
             # Make the self-energy Hermitian
             # This is done before adding the skew hermitian part coming
             # from the lesser and greater self-energies
-            self.data.sigma_retarded.symmetrize(xp.add)
+            self.data.sigma_retarded_hermitian.symmetrize(xp.add)
 
         if self.config.scba.align_self_energy_to_complex_axes:
             self.data.sigma_lesser._data.real = 0
             self.data.sigma_greater._data.real = 0
             # Make sure that the imaginary part comes only from
             # sigma_greater - sigma_lesser.
-            self.data.sigma_retarded._data.imag = 0
+            self.data.sigma_retarded_hermitian._data.imag = 0
 
     @profiler.profile(label="SCBA: Update Sigma", level="default", comm=comm)
     def _update_sigma(self) -> None:
@@ -385,16 +387,19 @@ class SCBA:
             (1 - self.mixing_factor) * self.data.sigma_greater_prev.data
             + self.mixing_factor * self.data.sigma_greater.data
         )
-        self.data.sigma_retarded.data[:] = (
-            (1 - self.mixing_factor) * self.data.sigma_retarded_prev.data
-            + self.mixing_factor * self.data.sigma_retarded.data
+        self.data.sigma_retarded_hermitian.data[:] = (
+            (1 - self.mixing_factor) * self.data.sigma_retarded_hermitian_prev.data
+            + self.mixing_factor * self.data.sigma_retarded_hermitian.data
         )
 
     @profiler.profile(label="SCBA: Convergence test", level="default", comm=comm)
     def _has_converged(self) -> bool:
         """Checks if the SCBA has converged."""
         # Infinity norm of the self-energy update.
-        diff = self.data.sigma_retarded.data - self.data.sigma_retarded_prev.data
+        diff = (
+            self.data.sigma_retarded_hermitian.data
+            - self.data.sigma_retarded_hermitian_prev.data
+        )
         local_max_diff = get_host(xp.max(xp.abs(diff)))
         max_diff = np.empty_like(local_max_diff)
         global_comm.Allreduce(local_max_diff, max_diff, op=MPI.MAX)
@@ -436,7 +441,7 @@ class SCBA:
                 out=(
                     self.data.sigma_lesser,
                     self.data.sigma_greater,
-                    self.data.sigma_retarded,
+                    self.data.sigma_retarded_hermitian,
                 ),
             )
 
@@ -477,7 +482,7 @@ class SCBA:
 
         self.sigma_fock.compute(
             self.data.g_lesser,
-            out=(self.data.sigma_retarded,),
+            out=(self.data.sigma_retarded_hermitian,),
         )
 
         self.sigma_coulomb_screening.compute(
@@ -488,7 +493,7 @@ class SCBA:
             out=(
                 self.data.sigma_lesser,
                 self.data.sigma_greater,
-                self.data.sigma_retarded,
+                self.data.sigma_retarded_hermitian,
             ),
         )
 
@@ -638,7 +643,7 @@ class SCBA:
                 self.electron_solver.solve(
                     self.data.sigma_lesser,
                     self.data.sigma_greater,
-                    self.data.sigma_retarded,
+                    self.data.sigma_retarded_hermitian,
                     out=(self.data.g_lesser, self.data.g_greater, self.data.g_retarded),
                 )
                 self._compute_electron_observables()
@@ -659,7 +664,7 @@ class SCBA:
                     for m in (
                         self.data.sigma_lesser,
                         self.data.sigma_greater,
-                        self.data.sigma_retarded,
+                        self.data.sigma_retarded_hermitian,
                     ):
                         m.dtranspose(discard=True)  # These can be safely discarded.
                         assert m.distribution_state == "nnz"
@@ -682,18 +687,13 @@ class SCBA:
                     for m in (
                         self.data.sigma_lesser,
                         self.data.sigma_greater,
-                        self.data.sigma_retarded,
+                        self.data.sigma_retarded_hermitian,
                     ):
                         m.dtranspose(discard=False)  # This must not be discarded.
                         assert m.distribution_state == "stack"
 
             # Symmetrize the self-energy.
             self._symmetrize_sigma()
-
-            # # Add the anti-Hermitian part to the retarded self-energy.
-            # self.data.sigma_retarded.data += 0.5 * (
-            #     self.data.sigma_greater.data - self.data.sigma_lesser.data
-            # )
 
             if self._has_converged():
                 if comm.rank == 0:

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -194,7 +194,6 @@ class Observables:
     w_lesser_density: NDArray = None
     w_greater_density: NDArray = None
 
-    p_retarded_density: NDArray = None
     p_lesser_density: NDArray = None
     p_greater_density: NDArray = None
 
@@ -551,9 +550,6 @@ class SCBA:
 
         # NOTE: The overlap is maybe missing here (it is not used)
         if self.config.outputs.polarization_density:
-            self.observables.p_retarded_density = -density(self.data.p_retarded) / (
-                2 * xp.pi
-            )
             self.observables.p_lesser_density = density(self.data.p_lesser) / (
                 2 * xp.pi
             )
@@ -602,7 +598,6 @@ class SCBA:
                     {
                         f"p_lesser_density_{iteration}.npy": self.observables.p_lesser_density,
                         f"p_greater_density_{iteration}.npy": self.observables.p_greater_density,
-                        f"p_retarded_density_{iteration}.npy": self.observables.p_retarded_density,
                     }
                 )
             if self.config.outputs.coulomb_screening_density:

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -122,8 +122,8 @@ class SCBAData:
         self.sigma_retarded_prev = dsdbsparse_type.zeros_like(self.g_lesser)
         self.sigma_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
         if config.scba.symmetric:
-            self.sigma_retarded.symmetry_op = lambda a: a
-            self.sigma_retarded_prev.symmetry_op = lambda a: a
+            self.sigma_retarded.symmetry_op = lambda a: a.conj()
+            self.sigma_retarded_prev.symmetry_op = lambda a: a.conj()
 
         if config.scba.coulomb_screening:
             # NOTE: The polarization has the same sparsity pattern as
@@ -187,7 +187,6 @@ class Observables:
     electron_photon_scattering_rate: NDArray = None
     electron_phonon_scattering_rate: NDArray = None
 
-    sigma_retarded_density: NDArray = None
     sigma_lesser_density: NDArray = None
     sigma_greater_density: NDArray = None
 
@@ -363,7 +362,9 @@ class SCBA:
         if not self.config.scba.symmetric:
             self.data.sigma_lesser.symmetrize(xp.subtract)
             self.data.sigma_greater.symmetrize(xp.subtract)
-            # Make the self-energy Hermitian (removing the skew-Hermitian part).
+            # Make the self-energy Hermitian
+            # This is done before adding the skew hermitian part coming
+            # from the lesser and greater self-energies
             self.data.sigma_retarded.symmetrize(xp.add)
 
         if self.config.scba.align_self_energy_to_complex_axes:
@@ -531,10 +532,6 @@ class SCBA:
                 )
 
         if self.config.outputs.self_energy_density:
-            self.observables.sigma_retarded_density = -density(
-                self.data.sigma_retarded,
-                self.electron_solver.overlap,
-            ) / (2 * xp.pi)
             self.observables.sigma_lesser_density = density(
                 self.data.sigma_lesser,
                 self.electron_solver.overlap,
@@ -614,7 +611,6 @@ class SCBA:
         if self.config.outputs.self_energy_density:
             outputs.update(
                 {
-                    f"sigma_retarded_density_{iteration}.npy": self.observables.sigma_retarded_density,
                     f"sigma_lesser_density_{iteration}.npy": self.observables.sigma_lesser_density,
                     f"sigma_greater_density_{iteration}.npy": self.observables.sigma_greater_density,
                 }
@@ -694,10 +690,10 @@ class SCBA:
             # Symmetrize the self-energy.
             self._symmetrize_sigma()
 
-            # Add the anti-Hermitian part to the retarded self-energy.
-            self.data.sigma_retarded.data += 0.5 * (
-                self.data.sigma_greater.data - self.data.sigma_lesser.data
-            )
+            # # Add the anti-Hermitian part to the retarded self-energy.
+            # self.data.sigma_retarded.data += 0.5 * (
+            #     self.data.sigma_greater.data - self.data.sigma_lesser.data
+            # )
 
             if self._has_converged():
                 if comm.rank == 0:

--- a/src/quatrex/core/scba.py
+++ b/src/quatrex/core/scba.py
@@ -130,9 +130,12 @@ class SCBAData:
             # the electronic system (the interactions are local in real
             # space). However, we need to change the block sizes of the
             # screened Coulomb interaction.
-            self.p_retarded = dsdbsparse_type.zeros_like(self.g_lesser)
+            self.p_retarded_hermitian = dsdbsparse_type.zeros_like(self.g_lesser)
             self.p_lesser = dsdbsparse_type.zeros_like(self.g_lesser)
             self.p_greater = dsdbsparse_type.zeros_like(self.g_lesser)
+
+            if config.scba.symmetric:
+                self.p_retarded_hermitian.symmetry_op = lambda a: a.conj()
 
             num_connected_blocks = config.coulomb_screening.num_connected_blocks
             if num_connected_blocks == "auto":
@@ -455,12 +458,16 @@ class SCBA:
 
         self.data.p_greater.allocate_data()
         self.data.p_lesser.allocate_data()
-        self.data.p_retarded.allocate_data()
+        self.data.p_retarded_hermitian.allocate_data()
 
         self.p_coulomb_screening.compute(
             self.data.g_lesser,
             self.data.g_greater,
-            out=(self.data.p_lesser, self.data.p_greater, self.data.p_retarded),
+            out=(
+                self.data.p_lesser,
+                self.data.p_greater,
+                self.data.p_retarded_hermitian,
+            ),
         )
 
         self.data.w_greater.allocate_data()
@@ -469,7 +476,7 @@ class SCBA:
         self.coulomb_screening_solver.solve(
             self.data.p_lesser,
             self.data.p_greater,
-            self.data.p_retarded,
+            self.data.p_retarded_hermitian,
             out=(self.data.w_lesser, self.data.w_greater),
         )
 
@@ -477,7 +484,7 @@ class SCBA:
 
         self.data.p_lesser.free_data()
         self.data.p_greater.free_data()
-        self.data.p_retarded.free_data()
+        self.data.p_retarded_hermitian.free_data()
 
         self.sigma_fock.compute(
             self.data.g_lesser,

--- a/src/quatrex/coulomb_screening/polarization.py
+++ b/src/quatrex/coulomb_screening/polarization.py
@@ -104,10 +104,10 @@ class PCoulombScreening(ScatteringSelfEnergy):
             The greater Green's function.
         out : tuple[DSDBSparse, ...]
             The output matrices for the polarization. The order is
-            p_lesser, p_greater, p_retarded.
+            p_lesser, p_greater, p_retarded_hermitian.
 
         """
-        p_lesser, p_greater, p_retarded = out
+        p_lesser, p_greater, p_retarded_hermitian = out
 
         # Barrier to synchronize ranks.
         with profiler.profile_range(
@@ -123,8 +123,8 @@ class PCoulombScreening(ScatteringSelfEnergy):
                 m.dtranspose(discard=True) if m.distribution_state != "nnz" else None
             if self.include_energy_renormalization:
                 (
-                    p_retarded.dtranspose(discard=True)
-                    if (p_retarded.distribution_state != "nnz")
+                    p_retarded_hermitian.dtranspose(discard=True)
+                    if (p_retarded_hermitian.distribution_state != "nnz")
                     else None
                 )
 
@@ -188,7 +188,7 @@ class PCoulombScreening(ScatteringSelfEnergy):
                     # Note that only the hermitian part is computed here.
 
                     if self.include_energy_renormalization:
-                        p_retarded.data[..., batch] = (
+                        p_retarded_hermitian.data[..., batch] = (
                             -(self.prefactor / 2)
                             * (
                                 hilbert_transform(
@@ -211,8 +211,8 @@ class PCoulombScreening(ScatteringSelfEnergy):
                 m.dtranspose() if m.distribution_state != "stack" else None
             if self.include_energy_renormalization:
                 (
-                    p_retarded.dtranspose()
-                    if (p_retarded.distribution_state != "stack")
+                    p_retarded_hermitian.dtranspose()
+                    if (p_retarded_hermitian.distribution_state != "stack")
                     else None
                 )
             # NOTE: The Green's functions must not be transposed back to
@@ -226,15 +226,13 @@ class PCoulombScreening(ScatteringSelfEnergy):
             if not p_lesser.symmetry:
                 p_lesser.symmetrize(xp.subtract)
                 p_greater.symmetrize(xp.subtract)
-                p_retarded.symmetrize(xp.add)
+                p_retarded_hermitian.symmetrize(xp.add)
 
             if not self.include_energy_renormalization:
-                p_retarded.data[:] = 0
+                p_retarded_hermitian.data[:] = 0
 
             # Discard the real part of lesser/greater and imag part of retarded
             if self.align_to_complex_axes:
                 p_lesser.data.real = 0
                 p_greater.data.real = 0
-                p_retarded.data.imag = 0
-
-            p_retarded.data += (p_greater.data - p_lesser.data) / 2
+                p_retarded_hermitian.data.imag = 0

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -40,6 +40,53 @@ def _compute_sparsity_pattern(
     )
 
 
+def _btd_assemble_polarization(
+    p_retarded: DSDBSparse,
+    p_lesser: DSDBSparse,
+    p_greater: DSDBSparse,
+    p_retarded_hermitian: DSDBSparse,
+) -> None:
+    r"""Assembles the full retarded polarization from the Hermitian part
+    and the lesser and greater parts.
+
+    $$\mathbf{P}^R = \mathbf{P}^R + \frac{1}{2} \left(\mathbf{P}^{>} - \mathbf{P}^{<} \right)$$
+
+    This is an in-place operation, i.e. the retarded polarization is modified.
+
+    Parameters
+    ----------
+    p_retarded : DSDBSparse
+        The retarded polarization.
+    p_lesser : DSDBSparse
+        The lesser polarization.
+    p_greater : DSDBSparse
+        The greater polarization.
+    p_retarded_hermitian : DSDBSparse
+        The hermitian part of the retarded polarization.
+
+    """
+    p_retarded_ = p_retarded.stack[...]
+    p_retarded_hermitian_ = p_retarded_hermitian.stack[...]
+    p_lesser_ = p_lesser.stack[...]
+    p_greater_ = p_greater.stack[...]
+    for i in range(p_retarded.num_local_blocks):
+        j = i + 1
+        p_retarded_.blocks[i, i] = p_retarded_hermitian_.blocks[i, i] + 0.5 * (
+            p_greater_.blocks[i, i] - p_lesser_.blocks[i, i]
+        )
+
+        if j >= p_retarded.num_local_blocks and comm.block.rank == comm.block.size - 1:
+            # The last rank does not have these blocks.
+            continue
+
+        p_retarded_.blocks[i, j] = p_retarded_hermitian_.blocks[i, j] + 0.5 * (
+            p_greater_.blocks[i, j] - p_lesser_.blocks[i, j]
+        )
+        p_retarded_.blocks[j, i] = p_retarded_hermitian_.blocks[j, i] + 0.5 * (
+            p_greater_.blocks[j, i] - p_lesser_.blocks[j, i]
+        )
+
+
 class CoulombScreeningSolver(SubsystemSolver):
     """Solves the dynamics of the screened Coulomb interaction.
 
@@ -140,6 +187,21 @@ class CoulombScreeningSolver(SubsystemSolver):
         del l_sparsity_pattern
         self.l_lesser.free_data()
         self.l_greater.free_data()
+
+        # Allocate object for the retarded polarization.
+        # This is only used as a temporary assembling the full retarded
+        # polarization before multiplying with the Coulomb matrix.
+        # This is simpler in case of domain distributed solver.
+        # Otherwise, it would be more memory efficient to directly assemble
+        # when doing the product with the Coulomb matrix, but the life time
+        # is not during the peak (quadratic solve).
+        self.p_retarded = config.compute.dsdbsparse_type.from_sparray(
+            sparsity_pattern.astype(xp.complex128),
+            block_sizes=self.small_block_sizes,
+            global_stack_shape=self.energies.shape
+            + tuple([k for k in kpoint_grid if k > 1]),
+        )
+        self.p_retarded.free_data()
 
         # Boundary conditions.
         self.left_occupancies = bose_einstein(
@@ -323,8 +385,25 @@ class CoulombScreeningSolver(SubsystemSolver):
     @profiler.profile(
         label="CoulombScreeningSolver: Assembly", level="default", comm=comm
     )
-    def _assemble_system_matrix(self, p_retarded: DSDBSparse) -> None:
-        """Assembles the system matrix."""
+    def _assemble_system_matrix(
+        self,
+        p_lesser: DSDBSparse,
+        p_greater: DSDBSparse,
+        p_retarded_hermitian: DSDBSparse,
+    ) -> None:
+        """Assembles the system matrix.
+
+        Parameters
+        ----------
+        p_lesser : DSDBSparse
+            The lesser polarization.
+        p_greater : DSDBSparse
+            The greater polarization.
+        p_retarded_hermitian : DSDBSparse
+            The hermitian part of the retarded polarization.
+             The anti-hermitian part is calculated from lesser and greater.
+
+        """
         self.system_matrix.data = 0.0
         local_blocks, _ = get_section_sizes(
             len(self.system_matrix.block_sizes), comm.block.size
@@ -332,14 +411,24 @@ class CoulombScreeningSolver(SubsystemSolver):
         start_block = sum(local_blocks[: comm.block.rank])
         end_block = start_block + local_blocks[comm.block.rank]
 
+        self.p_retarded.allocate_data()
+
+        _btd_assemble_polarization(
+            self.p_retarded,
+            p_lesser,
+            p_greater,
+            p_retarded_hermitian,
+        )
         bd_matmul_distr(
             self.coulomb_matrix,
-            p_retarded,
+            self.p_retarded,
             out=self.system_matrix,
             start_block=start_block,
             end_block=end_block,
             spillover_correction=True,
         )
+        self.p_retarded.free_data()
+
         xp.negative(self.system_matrix.data, out=self.system_matrix.data)
         self.system_matrix += sparse.eye(self.system_matrix.shape[-1])
 
@@ -391,7 +480,7 @@ class CoulombScreeningSolver(SubsystemSolver):
         self,
         p_lesser: DSDBSparse,
         p_greater: DSDBSparse,
-        p_retarded: DSDBSparse,
+        p_retarded_hermitian: DSDBSparse,
         out: tuple[DSDBSparse, ...],
     ) -> None:
         """Solves for the screened Coulomb interaction.
@@ -402,8 +491,9 @@ class CoulombScreeningSolver(SubsystemSolver):
             The lesser polarization.
         p_greater : DSDBSparse
             The greater polarization.
-        p_retarded : DSDBSparse
-            The retarded polarization.
+        p_retarded_hermitian : DSDBSparse
+            The hermitian part of the retarded polarization.
+            The anti-hermitian part is calculated from lesser and greater.
         out : tuple[DSDBSparse, ...]
             The output matrices. The order is (lesser, greater,
             retarded).
@@ -419,7 +509,7 @@ class CoulombScreeningSolver(SubsystemSolver):
             self._set_block_sizes(self.small_block_sizes)
 
         # Assemble the system matrix (Includes matrix multiplication).
-        self._assemble_system_matrix(p_retarded)
+        self._assemble_system_matrix(p_lesser, p_greater, p_retarded_hermitian)
 
         with profiler.profile_range(
             label="CoulombScreeningSolver: Sandwich", level="default", comm=comm

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -40,53 +40,6 @@ def _compute_sparsity_pattern(
     )
 
 
-def _btd_assemble_polarization(
-    p_retarded: DSDBSparse,
-    p_lesser: DSDBSparse,
-    p_greater: DSDBSparse,
-    p_retarded_hermitian: DSDBSparse,
-) -> None:
-    r"""Assembles the full retarded polarization from the Hermitian part
-    and the lesser and greater parts.
-
-    $$\mathbf{P}^R = \mathbf{P}^R + \frac{1}{2} \left(\mathbf{P}^{>} - \mathbf{P}^{<} \right)$$
-
-    This is an in-place operation, i.e. the retarded polarization is modified.
-
-    Parameters
-    ----------
-    p_retarded : DSDBSparse
-        The retarded polarization.
-    p_lesser : DSDBSparse
-        The lesser polarization.
-    p_greater : DSDBSparse
-        The greater polarization.
-    p_retarded_hermitian : DSDBSparse
-        The hermitian part of the retarded polarization.
-
-    """
-    p_retarded_ = p_retarded.stack[...]
-    p_retarded_hermitian_ = p_retarded_hermitian.stack[...]
-    p_lesser_ = p_lesser.stack[...]
-    p_greater_ = p_greater.stack[...]
-    for i in range(p_retarded.num_local_blocks):
-        j = i + 1
-        p_retarded_.blocks[i, i] = p_retarded_hermitian_.blocks[i, i] + 0.5 * (
-            p_greater_.blocks[i, i] - p_lesser_.blocks[i, i]
-        )
-
-        if j >= p_retarded.num_local_blocks and comm.block.rank == comm.block.size - 1:
-            # The last rank does not have these blocks.
-            continue
-
-        p_retarded_.blocks[i, j] = p_retarded_hermitian_.blocks[i, j] + 0.5 * (
-            p_greater_.blocks[i, j] - p_lesser_.blocks[i, j]
-        )
-        p_retarded_.blocks[j, i] = p_retarded_hermitian_.blocks[j, i] + 0.5 * (
-            p_greater_.blocks[j, i] - p_lesser_.blocks[j, i]
-        )
-
-
 class CoulombScreeningSolver(SubsystemSolver):
     """Solves the dynamics of the screened Coulomb interaction.
 
@@ -382,6 +335,53 @@ class CoulombScreeningSolver(SubsystemSolver):
                     a_nn_greater - a_nn_greater.conj().swapaxes(-1, -2)
                 )
 
+    def _assemble_retarded_polarization(
+        self,
+        p_lesser: DSDBSparse,
+        p_greater: DSDBSparse,
+        p_retarded_hermitian: DSDBSparse,
+    ) -> None:
+        r"""Assembles the full retarded polarization from the Hermitian part
+        and the lesser and greater parts.
+
+        $$\mathbf{P}^R = \mathbf{P}^R + \frac{1}{2} \left(\mathbf{P}^{>} - \mathbf{P}^{<} \right)$$
+
+        This modifies retarded polarization in-place i.e. the result is stored in `self.p_retarded`.
+
+        Parameters
+        ----------
+        p_lesser : DSDBSparse
+            The lesser polarization.
+        p_greater : DSDBSparse
+            The greater polarization.
+        p_retarded_hermitian : DSDBSparse
+            The hermitian part of the retarded polarization.
+
+        """
+        p_retarded_ = self.p_retarded.stack[...]
+        p_retarded_hermitian_ = p_retarded_hermitian.stack[...]
+        p_lesser_ = p_lesser.stack[...]
+        p_greater_ = p_greater.stack[...]
+        for i in range(self.p_retarded.num_local_blocks):
+            j = i + 1
+            p_retarded_.blocks[i, i] = p_retarded_hermitian_.blocks[i, i] + 0.5 * (
+                p_greater_.blocks[i, i] - p_lesser_.blocks[i, i]
+            )
+
+            if (
+                j >= self.p_retarded.num_local_blocks
+                and comm.block.rank == comm.block.size - 1
+            ):
+                # The last rank does not have these blocks.
+                continue
+
+            p_retarded_.blocks[i, j] = p_retarded_hermitian_.blocks[i, j] + 0.5 * (
+                p_greater_.blocks[i, j] - p_lesser_.blocks[i, j]
+            )
+            p_retarded_.blocks[j, i] = p_retarded_hermitian_.blocks[j, i] + 0.5 * (
+                p_greater_.blocks[j, i] - p_lesser_.blocks[j, i]
+            )
+
     @profiler.profile(
         label="CoulombScreeningSolver: Assembly", level="default", comm=comm
     )
@@ -413,8 +413,7 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         self.p_retarded.allocate_data()
 
-        _btd_assemble_polarization(
-            self.p_retarded,
+        self._assemble_retarded_polarization(
             p_lesser,
             p_greater,
             p_retarded_hermitian,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -93,42 +93,16 @@ def _btd_apply_potential(
         ) / 2
 
 
-def _btd_subtract(a: DSDBSparse, b: DSDBSparse) -> None:
-    """Subtracts b from a on the block-tridiagonal.
-
-    This is an in-place operation, i.e. a is modified.
-
-    Parameters
-    ----------
-    a : DSDBSparse
-        The matrix to subtract from.
-    b : DSDBSparse
-        The matrix to subtract.
-
-    """
-    a_ = a.stack[...]
-    b_ = b.stack[...]
-    for i in range(a.num_local_blocks):
-        j = i + 1
-        a_.blocks[i, i] -= b_.blocks[i, i]
-
-        if j >= a.num_local_blocks and comm.block.rank == comm.block.size - 1:
-            # The last rank does not have these blocks.
-            continue
-
-        a_.blocks[i, j] -= b_.blocks[i, j]
-        a_.blocks[j, i] -= b_.blocks[j, i]
-
-
-def _btd_subtract_sigma(
+def _btd_assemble(
     system_matrix: DSDBSparse,
+    hamiltonian: DSDBSparse,
     see_retarded: DSDBSparse,
     see_lesser: DSDBSparse,
     see_greater: DSDBSparse,
 ) -> None:
-    r"""Subtracts the self-energy from the system matrix on the block-tridiagonal.
+    r"""Subtracts the Hamiltonian and the self-energy from the system matrix on the block-tridiagonal.
 
-    $$\mathbf{M} \mathrel{{-}{=}} \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right) $$
+    $$\mathbf{M} \mathrel{{-}{=}} \mathbf{H} + \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right)$$
 
     This is an in-place operation, i.e. the system matrix is modified.
 
@@ -136,6 +110,8 @@ def _btd_subtract_sigma(
     ----------
     system_matrix : DSDBSparse
         The system matrix to subtract from.
+    hamiltonian : DSDBSparse
+        The Hamiltonian to subtract.
     see_retarded : DSDBSparse
         The retarded self-energy to subtract.
     see_lesser : DSDBSparse
@@ -145,13 +121,16 @@ def _btd_subtract_sigma(
 
     """
     system_matrix_ = system_matrix.stack[...]
+    hamiltonian_ = hamiltonian.stack[...]
     see_retarded_ = see_retarded.stack[...]
     see_lesser_ = see_lesser.stack[...]
     see_greater_ = see_greater.stack[...]
     for i in range(system_matrix.num_local_blocks):
         j = i + 1
-        system_matrix_.blocks[i, i] -= see_retarded_.blocks[i, i] + 0.5 * (
-            see_greater_.blocks[i, i] - see_lesser_.blocks[i, i]
+        system_matrix_.blocks[i, i] -= (
+            see_retarded_.blocks[i, i]
+            + 0.5 * (see_greater_.blocks[i, i] - see_lesser_.blocks[i, i])
+            + hamiltonian_.blocks[i, i]
         )
 
         if (
@@ -161,11 +140,15 @@ def _btd_subtract_sigma(
             # The last rank does not have these blocks.
             continue
 
-        system_matrix_.blocks[i, j] -= see_retarded_.blocks[i, j] + 0.5 * (
-            see_greater_.blocks[i, j] - see_lesser_.blocks[i, j]
+        system_matrix_.blocks[i, j] -= (
+            see_retarded_.blocks[i, j]
+            + 0.5 * (see_greater_.blocks[i, j] - see_lesser_.blocks[i, j])
+            + hamiltonian_.blocks[i, j]
         )
-        system_matrix_.blocks[j, i] -= see_retarded_.blocks[j, i] + 0.5 * (
-            see_greater_.blocks[j, i] - see_lesser_.blocks[j, i]
+        system_matrix_.blocks[j, i] -= (
+            see_retarded_.blocks[j, i]
+            + 0.5 * (see_greater_.blocks[j, i] - see_lesser_.blocks[j, i])
+            + hamiltonian_.blocks[j, i]
         )
 
 
@@ -492,8 +475,9 @@ class ElectronSolver(SubsystemSolver):
         else:
             _btd_apply_potential(self.system_matrix, self.overlap, self.potential)
 
-        _btd_subtract_sigma(self.system_matrix, sse_retarded, sse_lesser, sse_greater)
-        _btd_subtract(self.system_matrix, self.hamiltonian)
+        _btd_assemble(
+            self.system_matrix, self.hamiltonian, sse_retarded, sse_lesser, sse_greater
+        )
 
     def _filter_peaks(self, out: tuple[DSDBSparse, ...]) -> None:
         """Filters out peaks in the Green's functions.
@@ -556,7 +540,7 @@ class ElectronSolver(SubsystemSolver):
         sse_greater : DSDBSparse
             The greater self-energy.
         sse_retarded : DSDBSparse
-            The retarded self-energy.
+            The hermitian part of the retarded self-energy.
         out : tuple[DSDBSparse, ...]
             The output matrices. The order is (lesser, greater,
             retarded).
@@ -586,7 +570,9 @@ class ElectronSolver(SubsystemSolver):
                     hamiltonian=self.hamiltonian,
                     overlap=self.overlap,
                     potential=self.potential,
-                    sigma_retarded=sse_retarded,
+                    sigma_lesser=sse_lesser,
+                    sigma_greater=sse_greater,
+                    sigma_retarded_hermitian=sse_retarded,
                     energies=self.energies,
                     conduction_band_guesses=(
                         self.left_fermi_level + self.delta_fermi_level_conduction_band,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -120,6 +120,55 @@ def _btd_subtract(a: DSDBSparse, b: DSDBSparse) -> None:
         a_.blocks[j, i] -= b_.blocks[j, i]
 
 
+def _btd_subtract_sigma(
+    system_matrix: DSDBSparse,
+    see_retarded: DSDBSparse,
+    see_lesser: DSDBSparse,
+    see_greater: DSDBSparse,
+) -> None:
+    r"""Subtracts the self-energy from the system matrix on the block-tridiagonal.
+
+    $$\mathbf{M} \mathrel{{-}{=}} \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right) $$
+
+    This is an in-place operation, i.e. the system matrix is modified.
+
+    Parameters
+    ----------
+    system_matrix : DSDBSparse
+        The system matrix to subtract from.
+    see_retarded : DSDBSparse
+        The retarded self-energy to subtract.
+    see_lesser : DSDBSparse
+        The lesser self-energy to subtract.
+    see_greater : DSDBSparse
+        The greater self-energy to subtract.
+
+    """
+    system_matrix_ = system_matrix.stack[...]
+    see_retarded_ = see_retarded.stack[...]
+    see_lesser_ = see_lesser.stack[...]
+    see_greater_ = see_greater.stack[...]
+    for i in range(system_matrix.num_local_blocks):
+        j = i + 1
+        system_matrix_.blocks[i, i] -= see_retarded_.blocks[i, i] + 0.5 * (
+            see_greater_.blocks[i, i] - see_lesser_.blocks[i, i]
+        )
+
+        if (
+            j >= system_matrix.num_local_blocks
+            and comm.block.rank == comm.block.size - 1
+        ):
+            # The last rank does not have these blocks.
+            continue
+
+        system_matrix_.blocks[i, j] -= see_retarded_.blocks[i, j] + 0.5 * (
+            see_greater_.blocks[i, j] - see_lesser_.blocks[i, j]
+        )
+        system_matrix_.blocks[j, i] -= see_retarded_.blocks[j, i] + 0.5 * (
+            see_greater_.blocks[j, i] - see_lesser_.blocks[j, i]
+        )
+
+
 class ElectronSolver(SubsystemSolver):
     """Solves the electron dynamics.
 
@@ -412,13 +461,19 @@ class ElectronSolver(SubsystemSolver):
                 gamma_nn.copy(), self.right_occupancies - 1
             )
 
-    def _assemble_system_matrix(self, sse_retarded: DSDBSparse) -> None:
+    def _assemble_system_matrix(
+        self, sse_retarded: DSDBSparse, sse_lesser: DSDBSparse, sse_greater: DSDBSparse
+    ) -> None:
         """Assembles the system matrix.
 
         Parameters
         ----------
         sse_retarded : DSDBSparse
             The retarded scattering self-energy.
+        sse_lesser : DSDBSparse
+            The lesser scattering self-energy.
+        sse_greater : DSDBSparse
+            The greater scattering self-energy.
 
         """
         self.system_matrix.data = 0.0
@@ -437,7 +492,7 @@ class ElectronSolver(SubsystemSolver):
         else:
             _btd_apply_potential(self.system_matrix, self.overlap, self.potential)
 
-        _btd_subtract(self.system_matrix, sse_retarded)
+        _btd_subtract_sigma(self.system_matrix, sse_retarded, sse_lesser, sse_greater)
         _btd_subtract(self.system_matrix, self.hamiltonian)
 
     def _filter_peaks(self, out: tuple[DSDBSparse, ...]) -> None:
@@ -521,7 +576,7 @@ class ElectronSolver(SubsystemSolver):
         ):
             self.system_matrix.allocate_data()
 
-            self._assemble_system_matrix(sse_retarded)
+            self._assemble_system_matrix(sse_retarded, sse_lesser, sse_greater)
 
         if self.band_edge_tracking:
             with profiler.profile_range(

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -96,9 +96,9 @@ def _btd_apply_potential(
 def _btd_assemble(
     system_matrix: DSDBSparse,
     hamiltonian: DSDBSparse,
-    see_retarded: DSDBSparse,
-    see_lesser: DSDBSparse,
-    see_greater: DSDBSparse,
+    sse_lesser: DSDBSparse,
+    sse_greater: DSDBSparse,
+    sse_retarded_hermitian: DSDBSparse,
 ) -> None:
     r"""Subtracts the Hamiltonian and the self-energy from the system matrix on the block-tridiagonal.
 
@@ -112,24 +112,24 @@ def _btd_assemble(
         The system matrix to subtract from.
     hamiltonian : DSDBSparse
         The Hamiltonian to subtract.
-    see_retarded : DSDBSparse
-        The retarded self-energy to subtract.
-    see_lesser : DSDBSparse
+    sse_lesser : DSDBSparse
         The lesser self-energy to subtract.
-    see_greater : DSDBSparse
+    sse_greater : DSDBSparse
         The greater self-energy to subtract.
+    sse_retarded_hermitian : DSDBSparse
+        The retarded self-energy to subtract.
 
     """
     system_matrix_ = system_matrix.stack[...]
     hamiltonian_ = hamiltonian.stack[...]
-    see_retarded_ = see_retarded.stack[...]
-    see_lesser_ = see_lesser.stack[...]
-    see_greater_ = see_greater.stack[...]
+    sse_retarded_hermitian_ = sse_retarded_hermitian.stack[...]
+    sse_lesser_ = sse_lesser.stack[...]
+    sse_greater_ = sse_greater.stack[...]
     for i in range(system_matrix.num_local_blocks):
         j = i + 1
         system_matrix_.blocks[i, i] -= (
-            see_retarded_.blocks[i, i]
-            + 0.5 * (see_greater_.blocks[i, i] - see_lesser_.blocks[i, i])
+            sse_retarded_hermitian_.blocks[i, i]
+            + 0.5 * (sse_greater_.blocks[i, i] - sse_lesser_.blocks[i, i])
             + hamiltonian_.blocks[i, i]
         )
 
@@ -141,13 +141,13 @@ def _btd_assemble(
             continue
 
         system_matrix_.blocks[i, j] -= (
-            see_retarded_.blocks[i, j]
-            + 0.5 * (see_greater_.blocks[i, j] - see_lesser_.blocks[i, j])
+            sse_retarded_hermitian_.blocks[i, j]
+            + 0.5 * (sse_greater_.blocks[i, j] - sse_lesser_.blocks[i, j])
             + hamiltonian_.blocks[i, j]
         )
         system_matrix_.blocks[j, i] -= (
-            see_retarded_.blocks[j, i]
-            + 0.5 * (see_greater_.blocks[j, i] - see_lesser_.blocks[j, i])
+            sse_retarded_hermitian_.blocks[j, i]
+            + 0.5 * (sse_greater_.blocks[j, i] - sse_lesser_.blocks[j, i])
             + hamiltonian_.blocks[j, i]
         )
 
@@ -445,18 +445,21 @@ class ElectronSolver(SubsystemSolver):
             )
 
     def _assemble_system_matrix(
-        self, sse_retarded: DSDBSparse, sse_lesser: DSDBSparse, sse_greater: DSDBSparse
+        self,
+        sse_lesser: DSDBSparse,
+        sse_greater: DSDBSparse,
+        sse_retarded_hermitian: DSDBSparse,
     ) -> None:
         """Assembles the system matrix.
 
         Parameters
         ----------
-        sse_retarded : DSDBSparse
-            The retarded scattering self-energy.
         sse_lesser : DSDBSparse
             The lesser scattering self-energy.
         sse_greater : DSDBSparse
             The greater scattering self-energy.
+        sse_retarded_hermitian : DSDBSparse
+            The hermitian part of the retarded scattering self-energy.
 
         """
         self.system_matrix.data = 0.0
@@ -476,7 +479,11 @@ class ElectronSolver(SubsystemSolver):
             _btd_apply_potential(self.system_matrix, self.overlap, self.potential)
 
         _btd_assemble(
-            self.system_matrix, self.hamiltonian, sse_retarded, sse_lesser, sse_greater
+            self.system_matrix,
+            self.hamiltonian,
+            sse_lesser,
+            sse_greater,
+            sse_retarded_hermitian,
         )
 
     def _filter_peaks(self, out: tuple[DSDBSparse, ...]) -> None:
@@ -528,7 +535,7 @@ class ElectronSolver(SubsystemSolver):
         self,
         sse_lesser: DSDBSparse,
         sse_greater: DSDBSparse,
-        sse_retarded: DSDBSparse,
+        sse_retarded_hermitian: DSDBSparse,
         out: tuple[DSDBSparse, ...],
     ):
         """Solves for the electron Green's function.
@@ -539,7 +546,7 @@ class ElectronSolver(SubsystemSolver):
             The lesser self-energy.
         sse_greater : DSDBSparse
             The greater self-energy.
-        sse_retarded : DSDBSparse
+        sse_retarded_hermitian : DSDBSparse
             The hermitian part of the retarded self-energy.
         out : tuple[DSDBSparse, ...]
             The output matrices. The order is (lesser, greater,
@@ -553,14 +560,16 @@ class ElectronSolver(SubsystemSolver):
             ):
                 homogenize(sse_greater)
                 homogenize(sse_lesser)
-                homogenize(sse_retarded)
+                homogenize(sse_retarded_hermitian)
 
         with profiler.profile_range(
             label="ElectronSolver: Assemble", level="default", comm=comm
         ):
             self.system_matrix.allocate_data()
 
-            self._assemble_system_matrix(sse_retarded, sse_lesser, sse_greater)
+            self._assemble_system_matrix(
+                sse_lesser, sse_greater, sse_retarded_hermitian
+            )
 
         if self.band_edge_tracking:
             with profiler.profile_range(
@@ -572,7 +581,7 @@ class ElectronSolver(SubsystemSolver):
                     potential=self.potential,
                     sigma_lesser=sse_lesser,
                     sigma_greater=sse_greater,
-                    sigma_retarded_hermitian=sse_retarded,
+                    sigma_retarded_hermitian=sse_retarded_hermitian,
                     energies=self.energies,
                     conduction_band_guesses=(
                         self.left_fermi_level + self.delta_fermi_level_conduction_band,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -93,65 +93,6 @@ def _btd_apply_potential(
         ) / 2
 
 
-def _btd_assemble(
-    system_matrix: DSDBSparse,
-    hamiltonian: DSDBSparse,
-    sse_lesser: DSDBSparse,
-    sse_greater: DSDBSparse,
-    sse_retarded_hermitian: DSDBSparse,
-) -> None:
-    r"""Subtracts the Hamiltonian and the self-energy from the system matrix on the block-tridiagonal.
-
-    $$\mathbf{M} \mathrel{{-}{=}} \mathbf{H} + \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right)$$
-
-    This is an in-place operation, i.e. the system matrix is modified.
-
-    Parameters
-    ----------
-    system_matrix : DSDBSparse
-        The system matrix to subtract from.
-    hamiltonian : DSDBSparse
-        The Hamiltonian to subtract.
-    sse_lesser : DSDBSparse
-        The lesser self-energy to subtract.
-    sse_greater : DSDBSparse
-        The greater self-energy to subtract.
-    sse_retarded_hermitian : DSDBSparse
-        The retarded self-energy to subtract.
-
-    """
-    system_matrix_ = system_matrix.stack[...]
-    hamiltonian_ = hamiltonian.stack[...]
-    sse_retarded_hermitian_ = sse_retarded_hermitian.stack[...]
-    sse_lesser_ = sse_lesser.stack[...]
-    sse_greater_ = sse_greater.stack[...]
-    for i in range(system_matrix.num_local_blocks):
-        j = i + 1
-        system_matrix_.blocks[i, i] -= (
-            sse_retarded_hermitian_.blocks[i, i]
-            + 0.5 * (sse_greater_.blocks[i, i] - sse_lesser_.blocks[i, i])
-            + hamiltonian_.blocks[i, i]
-        )
-
-        if (
-            j >= system_matrix.num_local_blocks
-            and comm.block.rank == comm.block.size - 1
-        ):
-            # The last rank does not have these blocks.
-            continue
-
-        system_matrix_.blocks[i, j] -= (
-            sse_retarded_hermitian_.blocks[i, j]
-            + 0.5 * (sse_greater_.blocks[i, j] - sse_lesser_.blocks[i, j])
-            + hamiltonian_.blocks[i, j]
-        )
-        system_matrix_.blocks[j, i] -= (
-            sse_retarded_hermitian_.blocks[j, i]
-            + 0.5 * (sse_greater_.blocks[j, i] - sse_lesser_.blocks[j, i])
-            + hamiltonian_.blocks[j, i]
-        )
-
-
 class ElectronSolver(SubsystemSolver):
     """Solves the electron dynamics.
 
@@ -444,6 +385,59 @@ class ElectronSolver(SubsystemSolver):
                 gamma_nn.copy(), self.right_occupancies - 1
             )
 
+    def _subtract_hamiltonian_and_self_energy(
+        self,
+        sse_lesser: DSDBSparse,
+        sse_greater: DSDBSparse,
+        sse_retarded_hermitian: DSDBSparse,
+    ) -> None:
+        r"""Subtracts the Hamiltonian and the self-energy from the system matrix on the block-tridiagonal.
+
+        $$\mathbf{M} \mathrel{{-}{=}} \mathbf{H} + \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right)$$
+
+        This modifies the system matrix in-place, i.e. the result is stored in `self.system_matrix`.
+
+        Parameters
+        ----------
+        sse_lesser : DSDBSparse
+            The lesser self-energy to subtract.
+        sse_greater : DSDBSparse
+            The greater self-energy to subtract.
+        sse_retarded_hermitian : DSDBSparse
+            The retarded self-energy to subtract.
+
+        """
+        system_matrix_ = self.system_matrix.stack[...]
+        hamiltonian_ = self.hamiltonian.stack[...]
+        sse_retarded_hermitian_ = sse_retarded_hermitian.stack[...]
+        sse_lesser_ = sse_lesser.stack[...]
+        sse_greater_ = sse_greater.stack[...]
+        for i in range(self.system_matrix.num_local_blocks):
+            j = i + 1
+            system_matrix_.blocks[i, i] -= (
+                sse_retarded_hermitian_.blocks[i, i]
+                + 0.5 * (sse_greater_.blocks[i, i] - sse_lesser_.blocks[i, i])
+                + hamiltonian_.blocks[i, i]
+            )
+
+            if (
+                j >= self.system_matrix.num_local_blocks
+                and comm.block.rank == comm.block.size - 1
+            ):
+                # The last rank does not have these blocks.
+                continue
+
+            system_matrix_.blocks[i, j] -= (
+                sse_retarded_hermitian_.blocks[i, j]
+                + 0.5 * (sse_greater_.blocks[i, j] - sse_lesser_.blocks[i, j])
+                + hamiltonian_.blocks[i, j]
+            )
+            system_matrix_.blocks[j, i] -= (
+                sse_retarded_hermitian_.blocks[j, i]
+                + 0.5 * (sse_greater_.blocks[j, i] - sse_lesser_.blocks[j, i])
+                + hamiltonian_.blocks[j, i]
+            )
+
     def _assemble_system_matrix(
         self,
         sse_lesser: DSDBSparse,
@@ -478,9 +472,7 @@ class ElectronSolver(SubsystemSolver):
         else:
             _btd_apply_potential(self.system_matrix, self.overlap, self.potential)
 
-        _btd_assemble(
-            self.system_matrix,
-            self.hamiltonian,
+        self._subtract_hamiltonian_and_self_energy(
             sse_lesser,
             sse_greater,
             sse_retarded_hermitian,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -19,80 +19,6 @@ from quatrex.device.inputs import assemble_matrix
 profiler = Profiler()
 
 
-def _btd_add(a: DSDBSparse, b: DSDBSparse) -> None:
-    """Adds b to a on the block-tridiagonal.
-
-    This is an in-place operation, i.e. a is modified.
-
-    Parameters
-    ----------
-    a : DSDBSparse
-        The matrix to add to.
-    b : DSDBSparse
-        The matrix to add.
-
-    """
-    a_ = a.stack[...]
-    b_ = b.stack[...]
-    for i in range(a.num_local_blocks):
-        j = i + 1
-        a_.blocks[i, i] += b_.blocks[i, i]
-
-        if j >= a.num_local_blocks and comm.block.rank == comm.block.size - 1:
-            # The last rank does not have these blocks.
-            continue
-
-        a_.blocks[i, j] += b_.blocks[i, j]
-        a_.blocks[j, i] += b_.blocks[j, i]
-
-
-def _btd_apply_potential(
-    a: DSDBSparse, overlap: DSDBSparse, potential: NDArray
-) -> None:
-    """Applies the potential to a on the block-tridiagonal.
-
-    This is an in-place operation, i.e. a is modified.
-
-    Parameters
-    ----------
-    a : DSDBSparse
-        The matrix to apply the potential to.
-    overlap : DSDBSparse
-        The overlap matrix.
-    potential : NDArray
-        The potential to apply.
-
-    """
-    a_ = a.stack[...]
-    overlap_ = overlap.stack[...]
-    offset = 0
-    for i in range(a.num_local_blocks):
-        j = i + 1
-        s_ii = overlap_.blocks[i, i]
-        potential_i = potential[offset : offset + s_ii.shape[-1]]
-
-        a_.blocks[i, i] -= (
-            s_ii * potential_i[..., np.newaxis] + s_ii * potential_i
-        ) / 2
-
-        offset += s_ii.shape[-1]
-
-        if j >= a.num_local_blocks and comm.block.rank == comm.block.size - 1:
-            # The last rank does not have these blocks.
-            continue
-
-        s_ij = overlap_.blocks[i, j]
-        s_ji = overlap_.blocks[j, i]
-        potential_j = potential[offset : offset + s_ij.shape[-1]]
-
-        a_.blocks[i, j] -= (
-            s_ij * potential_i[..., np.newaxis] + s_ij * potential_j
-        ) / 2
-        a_.blocks[j, i] -= (
-            s_ji * potential_j[..., np.newaxis] + s_ji * potential_i
-        ) / 2
-
-
 class ElectronSolver(SubsystemSolver):
     """Solves the electron dynamics.
 
@@ -385,17 +311,99 @@ class ElectronSolver(SubsystemSolver):
                 gamma_nn.copy(), self.right_occupancies - 1
             )
 
+    def _add_overlap(
+        self,
+    ) -> None:
+        """Adds the overlap matrix to the system matrix.
+
+        This modifies the system matrix in-place, i.e. the result is stored in
+        `self.system_matrix`.
+
+        Parameters
+        ----------
+        self.system_matrix : DSDBSparse
+            The matrix to add to.
+        b : DSDBSparse
+            The matrix to add.
+
+        """
+        if not isinstance(self.overlap, DSDBSparse):
+            raise ValueError("Overlap matrix must be a DSDBSparse.")
+
+        system_matrix_ = self.system_matrix.stack[...]
+        overlap_ = self.overlap.stack[...]
+        for i in range(self.system_matrix.num_local_blocks):
+            j = i + 1
+            system_matrix_.blocks[i, i] += overlap_.blocks[i, i]
+
+            if (
+                j >= self.system_matrix.num_local_blocks
+                and comm.block.rank == comm.block.size - 1
+            ):
+                # The last rank does not have these blocks.
+                continue
+
+            system_matrix_.blocks[i, j] += overlap_.blocks[i, j]
+            system_matrix_.blocks[j, i] += overlap_.blocks[j, i]
+
+    def _apply_potential(
+        self,
+    ) -> None:
+        """Applies the potential to the system matrix.
+
+        This modifies the system matrix in-place, i.e. the result is stored in
+        `self.system_matrix`.
+
+        """
+        if not isinstance(self.overlap, DSDBSparse):
+            raise ValueError("Overlap matrix must be a DSDBSparse.")
+
+        system_matrix_ = self.system_matrix.stack[...]
+        overlap_ = self.overlap.stack[...]
+        offset = 0
+        for i in range(self.system_matrix.num_local_blocks):
+            j = i + 1
+            s_ii = overlap_.blocks[i, i]
+            potential_i = self.potential[offset : offset + s_ii.shape[-1]]
+
+            system_matrix_.blocks[i, i] -= (
+                s_ii * potential_i[..., np.newaxis] + s_ii * potential_i
+            ) / 2
+
+            offset += s_ii.shape[-1]
+
+            if (
+                j >= self.system_matrix.num_local_blocks
+                and comm.block.rank == comm.block.size - 1
+            ):
+                # The last rank does not have these blocks.
+                continue
+
+            s_ij = overlap_.blocks[i, j]
+            s_ji = overlap_.blocks[j, i]
+            potential_j = self.potential[offset : offset + s_ij.shape[-1]]
+
+            system_matrix_.blocks[i, j] -= (
+                s_ij * potential_i[..., np.newaxis] + s_ij * potential_j
+            ) / 2
+            system_matrix_.blocks[j, i] -= (
+                s_ji * potential_j[..., np.newaxis] + s_ji * potential_i
+            ) / 2
+
     def _subtract_hamiltonian_and_self_energy(
         self,
         sse_lesser: DSDBSparse,
         sse_greater: DSDBSparse,
         sse_retarded_hermitian: DSDBSparse,
     ) -> None:
-        r"""Subtracts the Hamiltonian and the self-energy from the system matrix on the block-tridiagonal.
+        r"""Subtracts the Hamiltonian and the self-energy from the system matrix
+        on the block-tridiagonal.
 
-        $$\mathbf{M} \mathrel{{-}{=}} \mathbf{H} + \mathbf{\Sigma}^R + \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right)$$
+        $$\mathbf{M} \mathrel{{-}{=}} \mathbf{H} + \mathbf{\Sigma}^R +
+        \frac{1}{2} \left(\mathbf{\Sigma}^{>} - \mathbf{\Sigma}^{<} \right)$$
 
-        This modifies the system matrix in-place, i.e. the result is stored in `self.system_matrix`.
+        This modifies the system matrix in-place, i.e. the result is stored in
+        `self.system_matrix`.
 
         Parameters
         ----------
@@ -460,7 +468,7 @@ class ElectronSolver(SubsystemSolver):
         if self.overlap is None:
             self.system_matrix.fill_diagonal(1.0)
         else:
-            _btd_add(self.system_matrix, self.overlap)
+            self._add_overlap()
 
         scale_stack(
             self.system_matrix.data,
@@ -470,7 +478,7 @@ class ElectronSolver(SubsystemSolver):
         if self.overlap is None:
             self.system_matrix -= sparse.diags(self.potential, format="csr")
         else:
-            _btd_apply_potential(self.system_matrix, self.overlap, self.potential)
+            self._apply_potential()
 
         self._subtract_hamiltonian_and_self_energy(
             sse_lesser,

--- a/src/quatrex/electron/sse_coulomb_screening.py
+++ b/src/quatrex/electron/sse_coulomb_screening.py
@@ -120,14 +120,14 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             The greater screened Coulomb interaction.
         out : tuple[DSDBSparse, ...]
             The output matrices for the self-energy. The order is
-            sigma_lesser, sigma_greater, sigma_retarded.
+            sigma_lesser, sigma_greater, sigma_retarded_hermitian.
         batch : slice
             The batch slice for the current computation.
         hilbert_kernel_fft : NDArray
             The precomputed Hilbert kernel in Fourier space.
 
         """
-        sigma_lesser, sigma_greater, sigma_retarded = out
+        sigma_lesser, sigma_greater, sigma_retarded_hermitian = out
 
         n = g_lesser.data.shape[0] + g_greater.data.shape[0] - 1
         ne = g_lesser.data.shape[0]
@@ -180,7 +180,7 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             # NOTE: The anti-Hermitian (sigma_greater - sigma_lesser)
             # part of the retarded self-energy is added outside in the
             # main SCBA loop, so it is not added here.
-            sigma_retarded.data[..., batch] += (
+            sigma_retarded_hermitian.data[..., batch] += (
                 self.prefactor
                 * xp.fft.ifft(sigma_x_fft, axis=0)[:ne]
                 * self.kpoint_volume
@@ -209,12 +209,12 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             The greater screened Coulomb interaction.
         out : tuple[DSDBSparse, ...]
             The output matrices for the self-energy. The order is
-            sigma_lesser, sigma_greater, sigma_retarded.
+            sigma_lesser, sigma_greater, sigma_retarded_hermitian.
         batch : slice
             The batch slice for the current computation.
 
         """
-        sigma_lesser, sigma_greater, sigma_retarded = out
+        sigma_lesser, sigma_greater, sigma_retarded_hermitian = out
         ne = g_lesser.data.shape[0]
 
         # Lesser self-energy
@@ -248,7 +248,7 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             # NOTE: The anti-Hermitian (sigma_greater - sigma_lesser)
             # part of the retarded self-energy is added outside in the
             # main SCBA loop, so it is not added here.
-            sigma_retarded.data[..., batch] += (
+            sigma_retarded_hermitian.data[..., batch] += (
                 self.prefactor
                 * hilbert_transform(sl, sg, self.energies)
                 * self.kpoint_volume
@@ -277,7 +277,7 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             The greater screened Coulomb interaction.
         out : tuple[DSDBSparse, ...]
             The output matrices for the self-energy. The order is
-            sigma_lesser, sigma_greater, sigma_retarded.
+            sigma_lesser, sigma_greater, sigma_retarded_hermitian.
 
         """
 
@@ -294,7 +294,7 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
             w_lesser.block_sizes = g_lesser.block_sizes
             w_greater.block_sizes = g_greater.block_sizes
 
-            sigma_lesser, sigma_greater, sigma_retarded = out
+            sigma_lesser, sigma_greater, sigma_retarded_hermitian = out
 
         with profiler.profile_range(
             label="SigmaCoulombScreening: stack->nnz transpose",
@@ -310,7 +310,7 @@ class SigmaCoulombScreening(ScatteringSelfEnergy):
                 g_greater,
                 sigma_lesser,
                 sigma_greater,
-                sigma_retarded,
+                sigma_retarded_hermitian,
             ):
                 # The electron Green's functions and self-energies should
                 # ideally already be in nnz-distribution. We cannot discard

--- a/src/quatrex/electron/sse_fock.py
+++ b/src/quatrex/electron/sse_fock.py
@@ -52,7 +52,7 @@ class SigmaFock(ScatteringSelfEnergy):
             The lesser Green's function.
         out : tuple[DSDBSparse, ...]
             The output matrices for the self-energy. The order is
-            sigma_retarded.
+            sigma_retarded_hermitian.
 
         """
         # TODO: Check again if we really need to transpose the matrices
@@ -60,8 +60,8 @@ class SigmaFock(ScatteringSelfEnergy):
         with profiler.profile_range(
             label="SigmaFock: stack->nnz transpose", level="default", comm=comm
         ):
-            (sigma_retarded,) = out
-            for m in (g_lesser, sigma_retarded):
+            (sigma_retarded_hermitian,) = out
+            for m in (g_lesser, sigma_retarded_hermitian):
                 # These should both already be in nnz-distribution.
                 m.dtranspose() if m.distribution_state != "nnz" else None
 
@@ -71,7 +71,7 @@ class SigmaFock(ScatteringSelfEnergy):
         ):
             if g_lesser.data.shape[-1] != 0:
                 gl_density = self.prefactor * g_lesser.data.sum(axis=0)
-                sigma_retarded.data += (
+                sigma_retarded_hermitian.data += (
                     fft_circular_convolve(
                         gl_density,
                         self.coulomb_matrix_data,

--- a/src/quatrex/electron/sse_phonon.py
+++ b/src/quatrex/electron/sse_phonon.py
@@ -61,7 +61,7 @@ class SigmaPhonon(ScatteringSelfEnergy):
             The greater Green's function.
         out : tuple[DSDBSparse, ...]
             The output matrices for the self-energy. The order is
-            sigma_lesser, sigma_greater, sigma_retarded.
+            sigma_lesser, sigma_greater, sigma_retarded_hermitian.
 
         """
         return self._compute_pseudo_scattering(g_lesser, g_greater, out)

--- a/tests/quatrex/bandstructure/test_band_edges.py
+++ b/tests/quatrex/bandstructure/test_band_edges.py
@@ -42,12 +42,12 @@ def _intialize(config: QuatrexConfig):
     dsdbsparse_type = config.compute.dsdbsparse_type
 
     # dummy self-energy
-    sigma_retarded = dsdbsparse_type.from_sparray(
+    sigma_dummy = dsdbsparse_type.from_sparray(
         sparsity_pattern.astype(xp.complex128),
         block_sizes=block_sizes,
         global_stack_shape=energies.shape + tuple([k for k in kpoint_grid if k > 1]),
     )
-    sigma_retarded.data[:] = 0
+    sigma_dummy.data[:] = 0
 
     section_offsets = xp.array([0, len(energies)])
 
@@ -55,10 +55,10 @@ def _intialize(config: QuatrexConfig):
     rank_left = xp.digitize(ind_left, section_offsets) - 1
     local_ind = (ind_left - section_offsets[rank_left],) + tuple(
         # Only take the k point indices
-        [s // 2 for s in sigma_retarded.shape[1:-2]]
+        [s // 2 for s in sigma_dummy.shape[1:-2]]
     )
 
-    return hamiltonian, overlap, potential, sigma_retarded, local_ind
+    return hamiltonian, overlap, potential, sigma_dummy, local_ind
 
 
 def test_subsectioning(
@@ -89,13 +89,15 @@ def test_subsectioning(
 
     setup_context(config)
 
-    hamiltonian, overlap, potential, sigma_retarded, local_ind = _intialize(config)
+    hamiltonian, overlap, potential, sigma_dummy, local_ind = _intialize(config)
 
     e_0_test = _compute_eigenvalues(
         hamiltonian=hamiltonian,
         overlap=overlap,
         potential=potential,
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(0, 0),
         upper_inds=(0, 1),
@@ -107,7 +109,9 @@ def test_subsectioning(
         hamiltonian=hamiltonian,
         overlap=overlap,
         potential=potential,
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(0, 0),
         upper_inds=(0, 1),
@@ -150,13 +154,15 @@ def test_left_right(
 
     setup_context(config)
 
-    hamiltonian, overlap, potential, sigma_retarded, local_ind = _intialize(config)
+    hamiltonian, overlap, potential, sigma_dummy, local_ind = _intialize(config)
 
     e_0_left = _compute_eigenvalues(
         hamiltonian=hamiltonian,
         overlap=overlap,
         potential=potential,
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(0, 0),
         upper_inds=(0, 1),
@@ -170,7 +176,9 @@ def test_left_right(
         hamiltonian=hamiltonian,
         overlap=overlap,
         potential=potential,
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(n, n),
         upper_inds=(n, m),
@@ -226,7 +234,7 @@ def test_overlap(
 
     setup_context(config)
 
-    hamiltonian, overlap, potential, sigma_retarded, local_ind = _intialize(config)
+    hamiltonian, overlap, potential, sigma_dummy, local_ind = _intialize(config)
 
     if overlap is None:
         pytest.skip("Skipping test for missing overlap matrix.")
@@ -242,7 +250,9 @@ def test_overlap(
         hamiltonian=hamiltonian,
         overlap=overlap,
         potential=potential,
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(0, 0),
         upper_inds=(0, 1),
@@ -261,7 +271,7 @@ def test_overlap(
 
     block_sizes = hamiltonian.block_sizes
     hamiltonian = hamiltonian.to_dense()
-    sigma_retarded = sigma_retarded.to_dense()
+    sigma_dummy = sigma_dummy.to_dense()
 
     L_inv_full = xp.zeros_like(hamiltonian)
     for i in range(len(block_sizes)):
@@ -276,13 +286,15 @@ def test_overlap(
     # NOTE: a mock class is used since it is not so straightforward
     # to do the correct DSDBSparse -> dense -> DSDBSparse conversion with the current API.
     hamiltonian = MockDSDBSparse(hamiltonian_hat, block_sizes)
-    sigma_retarded = MockDSDBSparse(sigma_retarded, block_sizes)
+    sigma_dummy = MockDSDBSparse(sigma_dummy, block_sizes)
 
     e_0_test = _compute_eigenvalues(
         hamiltonian=hamiltonian,
         overlap=None,
         potential=xp.zeros_like(potential),
-        sigma_retarded=sigma_retarded,
+        sigma_lesser=sigma_dummy,
+        sigma_greater=sigma_dummy,
+        sigma_retarded_hermitian=sigma_dummy,
         ind=local_ind,
         diagonal_inds=(0, 0),
         upper_inds=(0, 1),


### PR DESCRIPTION
This PR should fix the issues #278 and #279.

There are problems with the symmetry when not aligning to the complex axis or both P and Sigma.
The Hilbert parts generally contain imaginary parts, and when adding lesser/greater, the result is not complex symmetrical.
If we align, then they are symmetric.

We can fix this issue by keeping only the non-lesser/greater parts stored in Pr and SigmaR, and adding lesser/greater when Pr/SigmaR are used during the system matrix assembly G/W. 

This leads to extra additions, but we can further optimize when we align and store Pr/SigmaR as real instead of complex.



 