### PR TITLE
Fix pseudo phonons

### DIFF
--- a/src/quatrex/core/sse.py
+++ b/src/quatrex/core/sse.py
@@ -2,8 +2,6 @@
 
 from abc import ABC, abstractmethod
 
-from qttools.datastructures import DSDBSparse
-
 
 class ScatteringSelfEnergy(ABC):
     @abstractmethod
@@ -11,6 +9,6 @@ class ScatteringSelfEnergy(ABC):
         self,
         *args,
         **kwargs,
-    ) -> DSDBSparse:
+    ) -> None:
         """Computes the scattering self-energy."""
         ...

--- a/src/quatrex/electron/sse_phonon.py
+++ b/src/quatrex/electron/sse_phonon.py
@@ -40,34 +40,10 @@ class SigmaPhonon(ScatteringSelfEnergy):
                 self.phonon_energy, config.phonon.temperature
             )
 
-            # energy + hbar * omega
-            # <=> xp.roll(self.electron_energies, -upshift)[:-upshift]
-            self.upshift = xp.argmin(
+            # energy +- hbar * omega
+            self.shift = xp.argmin(
                 xp.abs(electron_energies - (electron_energies[0] + self.phonon_energy))
             )
-            # energy - hbar * omega
-            # <=> xp.roll(self.electron_energies, downshift)[downshift:]
-            self.downshift = (
-                electron_energies.size
-                - xp.argmin(
-                    xp.abs(
-                        electron_energies - (electron_energies[-1] - self.phonon_energy)
-                    )
-                )
-                - 1
-            )
-
-            self.valid_slice = (
-                slice(self.downshift, -self.upshift)
-                if self.upshift != 0
-                else slice(None)
-            )
-
-            totalshift = self.upshift + self.downshift
-
-            self.upslice = slice(None) if totalshift == 0 else slice(-totalshift)
-            self.downslice = slice(totalshift, None)
-
             return
 
         raise ValueError(f"Unknown phonon model: {config.phonon.model}")
@@ -111,69 +87,28 @@ class SigmaPhonon(ScatteringSelfEnergy):
             # These should ideally already be in nnz-distribution.
             m.dtranspose() if m.distribution_state != "nnz" else None
 
-        # ==== Using diagonal() ========================================
-        sl_diag = sigma_lesser.diagonal(stack_index=self.valid_slice)
+        ne = g_lesser.shape[0]
 
-        sl_diag += self.deformation_potential**2 * (
-            self.occupancy
-            * xp.roll(g_lesser.diagonal(), self.downshift, axis=0)[self.downslice]
-            + (self.occupancy + 1)
-            * xp.roll(g_lesser.diagonal(), -self.upshift, axis=0)[self.upslice]
+        sl_diag = sigma_lesser.diagonal()
+        gl_diag = g_lesser.diagonal()
+
+        sl_diag[: ne - self.shift] += self.deformation_potential**2 * (
+            (self.occupancy + 1) * gl_diag[self.shift :]
         )
-        sigma_lesser.fill_diagonal(sl_diag, stack_index=self.valid_slice)
-
-        sg_diag = sigma_greater.diagonal(stack_index=self.valid_slice)
-
-        sg_diag += self.deformation_potential**2 * (
-            self.occupancy
-            * xp.roll(g_greater.diagonal(), -self.upshift, axis=0)[self.upslice]
-            + (self.occupancy + 1)
-            * xp.roll(g_greater.diagonal(), self.downshift, axis=0)[self.downslice]
+        sl_diag[self.shift :] += self.deformation_potential**2 * (
+            self.occupancy * gl_diag[: ne - self.shift]
         )
-        sigma_greater.fill_diagonal(sg_diag, stack_index=self.valid_slice)
 
-        # ==== Diagonal only ===========================================
-        # inds = xp.diag_indices(sigma_lesser.shape[-1])
+        sigma_lesser.fill_diagonal(sl_diag)
 
-        # sigma_lesser.stack[self.valid_slice][*inds] += self.deformation_potential**2 * (
-        #     self.occupancy
-        #     * xp.roll(g_lesser[*inds], self.downshift, axis=0)[self.downslice]
-        #     + (self.occupancy + 1)
-        #     * xp.roll(g_lesser[*inds], -self.upshift, axis=0)[self.upslice]
-        # )
-        # sigma_greater.stack[self.valid_slice][
-        #     *inds
-        # ] += self.deformation_potential**2 * (
-        #     self.occupancy
-        #     * xp.roll(g_greater[*inds], -self.upshift, axis=0)[self.upslice]
-        #     + (self.occupancy + 1)
-        #     * xp.roll(g_greater[*inds], self.downshift, axis=0)[self.downslice]
-        # )
+        sg_diag = sigma_greater.diagonal()
+        gg_diag = g_greater.diagonal()
 
-        # ==== Full matrices ===========================================
-        # nnz_stop = sigma_lesser.nnz_section_sizes[comm.rank]
-        # stack_padding_inds = sigma_lesser._stack_padding_mask.nonzero()[0][
-        #     self.downshift : -self.upshift
-        # ]
-        # sigma_lesser._data[stack_padding_inds, ..., :nnz_stop] = (
-        #     self.deformation_potential**2
-        #     * (
-        #         self.occupancy
-        #         * xp.roll(g_lesser.data, self.downshift, axis=0)[self.totalshift :]
-        #         + (self.occupancy + 1)
-        #         * xp.roll(g_lesser.data, -self.upshift, axis=0)[: -self.totalshift]
-        #     )
-        # )
-        # sigma_greater._data[stack_padding_inds, ..., :nnz_stop] = (
-        #     self.deformation_potential**2
-        #     * (
-        #         self.occupancy
-        #         * xp.roll(g_greater.data, -self.upshift, axis=0)[: -self.totalshift]
-        #         + (self.occupancy + 1)
-        #         * xp.roll(g_greater.data, self.downshift, axis=0)[self.totalshift :]
-        #     )
-        # )
+        sg_diag[: ne - self.shift] += self.deformation_potential**2 * (
+            self.occupancy * gg_diag[self.shift :]
+        )
+        sg_diag[self.shift :] += self.deformation_potential**2 * (
+            (self.occupancy + 1) * gg_diag[: ne - self.shift]
+        )
 
-        # NOTE: The electron Green's functions and self-energies must
-        # not be transposed back to stack distribution, as they are
-        # needed in nnz distribution for the other interactions.
+        sigma_greater.fill_diagonal(sg_diag)

--- a/src/quatrex/electron/sse_phonon.py
+++ b/src/quatrex/electron/sse_phonon.py
@@ -87,7 +87,7 @@ class SigmaPhonon(ScatteringSelfEnergy):
             # These should ideally already be in nnz-distribution.
             m.dtranspose() if m.distribution_state != "nnz" else None
 
-        ne = g_lesser.shape[0]
+        ne = g_lesser.data.shape[0]
 
         sl_diag = sigma_lesser.diagonal()
         gl_diag = g_lesser.diagonal()

--- a/src/quatrex/electron/sse_phonon.py
+++ b/src/quatrex/electron/sse_phonon.py
@@ -81,9 +81,9 @@ class SigmaPhonon(ScatteringSelfEnergy):
             The lesser, greater and retarded self-energies.
 
         """
-        sigma_lesser, sigma_greater, sigma_retarded = out
+        sigma_lesser, sigma_greater, __ = out
         # Transpose the matrices to nnz distribution.
-        for m in (g_lesser, g_greater, sigma_lesser, sigma_greater, sigma_retarded):
+        for m in (g_lesser, g_greater, sigma_lesser, sigma_greater):
             # These should ideally already be in nnz-distribution.
             m.dtranspose() if m.distribution_state != "nnz" else None
 


### PR DESCRIPTION
Previously, the shifting was not done correctly. The rolling and slicing did lead to unexpected results.
This was fixed by not rolling anymore, but by explicit slicing.

Note: It could be better to only take the valid part, but this follows OMEN/Matlab.