### PR TITLE
Transver periodic obc

### DIFF
--- a/src/qttools/boundary_conditions/obc/spectral.py
+++ b/src/qttools/boundary_conditions/obc/spectral.py
@@ -232,15 +232,6 @@ class Spectral(OBCSolver):
 
         """
 
-        batchsize = a_xx[0].shape[0]
-
-        if batchsize != 1 and find_injected:
-            # TODO: We keep this restriction, as we have not tested the
-            # injection vector calculation with batchsize > 1 yet.
-            raise ValueError(
-                "The injection vector can only be calculated with batchsize = 1"
-            )
-
         # Calculate the residual
         with warnings.catch_warnings(action="ignore", category=RuntimeWarning):
 

--- a/src/qttools/toeplitz/__init__.py
+++ b/src/qttools/toeplitz/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.

--- a/src/qttools/toeplitz/circulant.py
+++ b/src/qttools/toeplitz/circulant.py
@@ -85,7 +85,42 @@ def _get_idft_matrix(n: int) -> NDArray:
     return w
 
 
-def _transform_matrix(
+def _2D_fft(a: NDArray):
+    """Apply the 2D discrete Fourier transform (DFT) to the input array a. The
+    DFT is applied along the first two dimensions of a.
+    The DFT is done explictly using the DFT matrices, which is not the most efficient way for
+    many sections, but it is assumed that the number of sections is small.
+
+    Parameters
+    ----------
+    a : NDArray
+        The input array to transform. The first two dimensions are assumed to be the section dimensions.
+
+    Returns
+    -------
+    NDArray
+        The transformed array after applying the 2D DFT along the first two dimensions.
+
+    """
+
+    sections_y = a.shape[0]
+    sections_x = a.shape[1]
+
+    # stores the first block-layer of the system, which has the shape
+    # (sections_y, sections_x, batch_size, block_size_y, block_size_x)
+    dft_x = _get_dft_matrix(sections_x)
+    dft_y = _get_dft_matrix(sections_y)
+
+    # Transform along the y-sections
+    a = xp.einsum("ij, jk... -> ik...", dft_y, a)
+
+    # Transform along the x-sections
+    a = xp.einsum("ij, kj... -> ki...", dft_x, a)
+
+    return a
+
+
+def transform_circulant(
     a: NDArray,
     sections_x: int = 1,
     sections_y: int = 1,
@@ -156,28 +191,16 @@ def _transform_matrix(
     # view along y direction
     a = _block_view(a[..., :block_size_y, :], axis=-1, num_blocks=sections_y)
 
-    # a now stores the first block-layer of the system, which has the shape
-    # (sections_y, sections_x, batch_size, block_size_y, block_size_x)
-
-    dft_x = _get_dft_matrix(sections_x)
-    dft_y = _get_dft_matrix(sections_y)
-
-    # Transform along the y-sections
-    a = xp.einsum("ij, jklmn -> iklmn", dft_y, a)
-
-    # Transform along the x-sections
-    a = xp.einsum("ij, kjlmn -> kilmn", dft_x, a)
-
-    return a
+    return _2D_fft(a)
 
 
-def _detransform_matrix(
+def detransform_circulant(
     a: NDArray,
     sections_x: int = 1,
     sections_y: int = 1,
 ) -> NDArray:
     """Inverse transformation of the block diagonal form to the original matrix
-    form. This is the inverse of the _transform_matrix function and uses the
+    form. This is the inverse of the `transform_circulant` function and uses the
     inverse DFT matrices.
 
     Parameters
@@ -248,20 +271,19 @@ def _detransform_matrix(
     return out
 
 
-def transform_system(
-    a_xx: list[NDArray],
-    phase: complex = 1,
+def transform_phi_circulant(
+    a: NDArray,
+    phase_x: complex = 1,
+    phase_y: complex = 1,
     sections_x: int = 1,
     sections_y: int = 1,
 ):
-    r"""Transform the boundary system to block diagonal form by exploiting the
-    circulant structure of the system. This transformation is based on the
-    discrete Fourier transform (DFT) and can be applied to systems with
-    periodicity in transverse direction. It is assumed that the system is
+    r"""Transform a matrix to block diagonal form by exploiting the
+    $\phi$-circulant structure of the matrix. This transformation is based on the
+    discrete Fourier transform (DFT). It is assumed that the matrix is
     already sorted according to the transverse direction.
     
-    A phase needs to be provided for non-gamma point caculation since the the
-    system is not circulant, but rather $\phi$-circulant i.e. has the form of:
+    Being $\phi$-circulant implies that the matrix has the form of:
 
     \[
         \mathbf{A} = \begin{bmatrix}
@@ -280,11 +302,110 @@ def transform_system(
     \[
         \mathbf{D} = \begin{bmatrix}
             1 & 0 & 0 \\
-            0 & a & 0 \\
-            0 & 0 & c
+            0 & \phi^{\frac{1}{3}} & 0 \\
+            0 & 0 & \phi^{\frac{2}{3}}
         \end{bmatrix}
     \]
 
+    For the case of a 2D $\phi$-circulant structure, the matrix has the same
+    form as above, but each block is again $\phi$-circulant.
+
+    Parameters
+    ----------
+    a : NDArray
+        The matrix to transform. The last two dimensions are assumed to be
+        square and the last dimension is assumed to be divisible by sections_x
+        and sections_y.
+    phase_x : complex, optional
+        The phase shift in the x direction, by default 1.
+    phase_y : complex, optional
+        The phase shift in the y direction, by default 1.
+    sections_x : int, optional 
+        The number of sections in the x direction, by default 1.
+    sections_y : int, optional
+        The number of sections in the y direction, by default 1.
+
+    Returns
+    -------
+    NDArray
+        The transformed matrix in block diagonal form.
 
     """
-    ...
+
+    if a.ndim == 2:
+        a = a[None, ...]
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+
+    block_size_x = a.shape[-1] // sections_x
+
+    if block_size_x % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+
+    block_size_y = block_size_x // sections_y
+
+    # view along x direction
+    a = _block_view(a[..., :block_size_x, :], axis=-1, num_blocks=sections_x)
+    # view along y direction
+    a = _block_view(a[..., :block_size_y, :], axis=-1, num_blocks=sections_y)
+
+    # the problem can be transformed to the circulant case
+    # where the is a phase shift on the blocks
+
+    beta_x = phase_x ** (1 / sections_x)
+    beta_y = phase_y ** (1 / sections_y)
+
+    betas_x = xp.array([beta_x**i for i in range(sections_x)])
+    betas_y = xp.array([beta_y**i for i in range(sections_y)])
+
+    beta = betas_y[:, None] * betas_x[None, :]
+    a = a * beta[..., None, None, None]
+
+    return _2D_fft(a)
+
+
+def detransform_phi_circulant(
+    a: NDArray,
+    phase_x: complex = 1,
+    phase_y: complex = 1,
+    sections_x: int = 1,
+    sections_y: int = 1,
+) -> NDArray:
+    """Inverse transformation of the block diagonal form to the original matrix
+    form. This is the inverse of the `transform_phi_circulant` function and uses the
+    inverse DFT matrices.
+
+    Parameters
+    ----------
+    a : NDArray
+        The matrix to detransform.
+    phase_x : complex, optional
+        The phase shift in the x direction, by default 1.
+    phase_y : complex, optional
+        The phase shift in the y direction, by default 1.
+    sections_x : int, optional
+        The number of sections in the x direction, by default 1.
+    sections_y : int, optional
+        The number of sections in the y direction, by default 1.
+
+    Returns
+    -------
+    NDArray
+        The original matrix before transformation.
+
+    """
+    block_size_y = a.shape[-1]
+
+    out = detransform_circulant(a, sections_x, sections_y)
+
+    # need to apply the inverse of the phase transformation
+    beta_x = phase_x ** (1 / sections_x)
+    beta_y = phase_y ** (1 / sections_y)
+
+    betas_x = xp.array([beta_x**i for i in range(sections_x)])
+    betas_y = xp.array([beta_y**i for i in range(sections_y)])
+
+    beta = xp.kron(betas_x, xp.kron(betas_y, xp.ones(block_size_y)))
+
+    return (out * beta[None, :, None]) / beta[None, None, :]

--- a/src/qttools/toeplitz/circulant.py
+++ b/src/qttools/toeplitz/circulant.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
+
+
+from qttools import NDArray, xp
+from qttools.datastructures.dsdbsparse import _block_view
+
+
+def check_circulant(a: NDArray, sections: int) -> bool:
+    """Check if a matrix is block circulant with the given number of sections.
+
+    Parameters
+    ----------
+    a : NDArray
+        The matrix to check.
+    sections : int
+        The number of sections in the block circulant structure.
+
+    Returns
+    -------
+    bool
+        True if a is block circulant with the given number of sections, False otherwise.
+
+    """
+    if a.shape[-1] % sections != 0:
+        raise ValueError("The last dimension of a must be divisible by sections.")
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size = a.shape[-1] // sections
+    # Take the first block-row (top n rows)
+    block_layer = a[..., :block_size, :]
+    blocks = xp.split(block_layer, sections, axis=-1)
+
+    for i in range(sections):
+        shifted_blocks = blocks[-i:] + blocks[:-i]
+        if not xp.allclose(
+            a[..., i * block_size : (i + 1) * block_size, :],
+            xp.concatenate(shifted_blocks, axis=-1),
+        ):
+            return False
+
+    return True
+
+
+def _get_dft_matrix(n: int) -> NDArray:
+    """Get the discrete Fourier transform (DFT) matrix of size n x n.
+
+    Parameters
+    ----------
+    n : int
+        The size of the DFT matrix.
+
+    Returns
+    -------
+    NDArray
+        The DFT matrix of size n x n.
+
+    """
+    k = xp.arange(n)
+    j = xp.arange(n)
+    w = xp.exp(-2j * xp.pi * k[:, None] * j / n) / xp.sqrt(n)
+    return w
+
+
+def _get_idft_matrix(n: int) -> NDArray:
+    """Get the inverse discrete Fourier transform (IDFT) matrix of size n x n.
+
+    Parameters
+    ----------
+    n : int
+        The size of the IDFT matrix.
+
+    Returns
+    -------
+    NDArray
+        The IDFT matrix of size n x n.
+
+    """
+    k = xp.arange(n)
+    j = xp.arange(n)
+    w = xp.exp(2j * xp.pi * k[:, None] * j / n) / xp.sqrt(n)
+    return w
+
+
+def _transform_matrix(
+    a: NDArray,
+    sections_x: int = 1,
+    sections_y: int = 1,
+) -> NDArray:
+    r"""Transform a matrix to block diagonal form by exploiting the
+    circulant structure of the matrix. This transformation is based on the
+    discrete Fourier transform (DFT) and can be applied to systems with
+    periodicity in transverse direction. It is assumed that the matrix is
+    already sorted according to the transverse direction.
+    
+    \[
+        \mathbf{A} = \begin{bmatrix}
+            a & b & c \\
+            c & a & b \\
+            b & c & a
+        \end{bmatrix}
+    \]
+    which is circulant with `sections_x=3` sections, and 
+    each block is again block circulant with `sections_y` sections.
+
+    which can be decomposed with the 2D DFT matrix $\mathbf{F}$ as
+    \[
+        \mathbf{A} = \mathbf{F}^{-1} \mathbf{B} \mathbf{F}
+    \]
+    where 
+    \[
+        \mathbf{F} = \mathbf{F}_x \otimes \mathbf{F}_y \otimes \mathbf{I}
+    \]
+
+    This uses explicitly the DFT matrix, which is not the most efficient way for
+    many sections, but it is assumed that the number of sections is small.
+    The DFT matrices are explicitly used to simplify when transforming non-matrix
+    quantities for the boundary conditions.
+
+    Parameters
+    ----------
+    a : NDArray
+        The matrix to transform. The last two dimensions are assumed to be
+        square and the last dimension is assumed to be divisible by sections_x
+        and sections_y.
+    sections_x : int, optional 
+        The number of sections in the x direction, by default 1.
+    sections_y : int, optional
+        The number of sections in the y direction, by default 1.
+
+    Returns
+    -------
+    NDArray
+        The transformed matrix in block diagonal form.
+
+    """
+
+    if a.ndim == 2:
+        a = a[None, ...]
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+
+    block_size_x = a.shape[-1] // sections_x
+
+    if block_size_x % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+
+    block_size_y = block_size_x // sections_y
+
+    # view along x direction
+    a = _block_view(a[..., :block_size_x, :], axis=-1, num_blocks=sections_x)
+    # view along y direction
+    a = _block_view(a[..., :block_size_y, :], axis=-1, num_blocks=sections_y)
+
+    # a now stores the first block-layer of the system, which has the shape
+    # (sections_y, sections_x, batch_size, block_size_y, block_size_x)
+
+    dft_x = _get_dft_matrix(sections_x)
+    dft_y = _get_dft_matrix(sections_y)
+
+    # Transform along the y-sections
+    a = xp.einsum("ij, jklmn -> iklmn", dft_y, a)
+
+    # Transform along the x-sections
+    a = xp.einsum("ij, kjlmn -> kilmn", dft_x, a)
+
+    return a
+
+
+def _detransform_matrix(
+    a: NDArray,
+    sections_x: int = 1,
+    sections_y: int = 1,
+) -> NDArray:
+    """Inverse transformation of the block diagonal form to the original matrix
+    form. This is the inverse of the _transform_matrix function and uses the
+    inverse DFT matrices.
+
+    Parameters
+    ----------
+    a : NDArray
+        The matrix to detransform.
+    sections_x : int, optional
+        The number of sections in the x direction, by default 1.
+    sections_y : int, optional
+        The number of sections in the y direction, by default 1.
+
+    Returns
+    -------
+    NDArray
+        The original matrix before transformation.
+
+    """
+
+    if a.ndim != 5:
+        raise ValueError(
+            "The input matrix must have 5 dimensions after transformation."
+        )
+
+    if a.shape[0] != sections_y:
+        raise ValueError("The first dimension of a must be equal to sections_y.")
+    if a.shape[1] != sections_x:
+        raise ValueError("The second dimension of a must be equal to sections_x.")
+
+    block_size_y = a.shape[-1]
+    block_size_x = block_size_y * a.shape[0]
+    batch_size = a.shape[2]
+
+    idft_x = _get_idft_matrix(sections_x)
+    idft_y = _get_idft_matrix(sections_y)
+
+    # Transform along the y-sections
+    a = xp.einsum("ij, jklmn -> iklmn", idft_y, a)
+
+    # Transform along the x-sections
+    a = xp.einsum("ij, kjlmn -> kilmn", idft_x, a)
+
+    # expand first in the y direction
+    # the temporary has the shape (sections_x, batch_size, block_size_x, block_size_x)
+    tmp = xp.zeros((sections_x, batch_size, block_size_x, block_size_x), dtype=a.dtype)
+    a = a.transpose(1, 2, 3, 0, 4).reshape(
+        sections_x, batch_size, block_size_y, block_size_x
+    )
+
+    for i in range(0, block_size_x, block_size_y):
+        tmp[..., i : i + block_size_y, :] = a
+        # roll the layer
+        a = xp.roll(a, block_size_y, axis=-1)
+
+    # expand first in the x direction
+    tmp = tmp.transpose(1, 2, 0, 3).reshape(
+        batch_size, block_size_x, block_size_x * sections_x
+    )
+    out = xp.zeros(
+        (batch_size, block_size_x * sections_x, block_size_x * sections_x),
+        dtype=a.dtype,
+    )
+
+    for i in range(0, block_size_x * sections_x, block_size_x):
+        out[..., i : i + block_size_x, :] = tmp
+        # roll the layer
+        tmp = xp.roll(tmp, block_size_x, axis=-1)
+
+    return out
+
+
+def transform_system(
+    a_xx: list[NDArray],
+    phase: complex = 1,
+    sections_x: int = 1,
+    sections_y: int = 1,
+):
+    r"""Transform the boundary system to block diagonal form by exploiting the
+    circulant structure of the system. This transformation is based on the
+    discrete Fourier transform (DFT) and can be applied to systems with
+    periodicity in transverse direction. It is assumed that the system is
+    already sorted according to the transverse direction.
+    
+    A phase needs to be provided for non-gamma point caculation since the the
+    system is not circulant, but rather $\phi$-circulant i.e. has the form of:
+
+    \[
+        \mathbf{A} = \begin{bmatrix}
+            a & b & c \\
+            \phi c & a & b \\
+            \phi b & \phi c & a
+        \end{bmatrix}
+    \]
+
+    which can be decomposed into a circulant matrix by 
+    \[
+        \mathbf{A} = \mathbf{D} \mathbf{B} \mathbf{D}^{-1}
+    \]
+
+    where 
+    \[
+        \mathbf{D} = \begin{bmatrix}
+            1 & 0 & 0 \\
+            0 & a & 0 \\
+            0 & 0 & c
+        \end{bmatrix}
+    \]
+
+
+    """
+    ...

--- a/src/qttools/toeplitz/circulant.py
+++ b/src/qttools/toeplitz/circulant.py
@@ -225,7 +225,7 @@ def _get_idft_matrix(n: int) -> NDArray:
     return w
 
 
-def _2D_fft(a: NDArray):
+def _2D_dft(a: NDArray):
     """Apply the 2D discrete Fourier transform (DFT) to the input array a. The
     DFT is applied along the first two dimensions of a.
     The DFT is done explictly using the DFT matrices, which is not the most efficient way for
@@ -257,7 +257,42 @@ def _2D_fft(a: NDArray):
     # Transform along the x-sections
     a = xp.einsum("ij, kj... -> ki...", dft_x, a)
 
-    return a
+    return a * xp.sqrt(sections_x * sections_y)
+
+
+def _2D_idft(a: NDArray) -> NDArray:
+    """Apply the 2D inverse discrete Fourier transform (IDFT) to the input array
+    a along the first two dimensions, scaled to match the block-diagonal form.
+    The IDFT is done explictly using the DFT matrices, which is not the most
+    efficient way for many sections, but it is assumed that the number of
+    sections is small.
+
+    Parameters
+    ----------
+    a : NDArray
+        The input array to transform. The first two dimensions are assumed to be
+        the section dimensions.
+
+    Returns
+    -------
+    NDArray
+        The transformed array after applying the 2D IDFT along the first two
+        dimensions.
+
+    """
+    sections_y = a.shape[0]
+    sections_x = a.shape[1]
+
+    idft_x = _get_idft_matrix(sections_x)
+    idft_y = _get_idft_matrix(sections_y)
+
+    # Transform along the y-sections
+    a = xp.einsum("ij, jk... -> ik...", idft_y, a)
+
+    # Transform along the x-sections
+    a = xp.einsum("ij, kj... -> ki...", idft_x, a)
+
+    return a / xp.sqrt(sections_x * sections_y)
 
 
 def transform_circulant(
@@ -331,13 +366,76 @@ def transform_circulant(
     # view along y direction
     a = _block_view(a[..., :block_size_y, :], axis=-1, num_blocks=sections_y)
 
-    return _2D_fft(a)
+    return _2D_dft(a)
+
+
+def _core_detransform(
+    a: NDArray,
+    phase_x: NDArray | None = None,
+    phase_y: NDArray | None = None,
+) -> NDArray:
+    """Core helper that handles the 2D matrix DFT, phase modulation,
+    and block-interleaving layout reconstruction.
+
+    Parameters
+    ----------
+    a : NDArray
+        The input array in block diagonal form. The first two dimensions are
+        assumed to be the section dimensions, the third dimension is the batch
+        dimension, the fourth dimension is the block size, and the fifth
+        dimension is the number of eigenvalues per block.
+    phase_x : NDArray | None, optional
+        The phase factors for the x direction, by default None. If provided, it
+        should have shape (batch_size,).
+    phase_y : NDArray | None, optional
+        The phase factors for the y direction, by default None. If provided, it
+        should have shape (batch_size,).
+
+    Returns
+    -------
+    NDArray
+        The detransformed array in the original matrix form. The first dimension
+        is the batch dimension, the second and third dimensions are the original
+        matrix dimensions, and the fourth dimension is the number of
+        eigenvalues.
+
+    """
+    sections_y, sections_x = a.shape[0], a.shape[1]
+    batch_size = a.shape[2]
+    block_size_y = a.shape[3]
+
+    dft_x = _get_dft_matrix(sections_x)
+    dft_y = _get_dft_matrix(sections_y)
+
+    if phase_x is not None and phase_y is not None:
+        beta_x = phase_x ** (1 / sections_x)
+        beta_y = phase_y ** (1 / sections_y)
+        bx = xp.array([beta_x**i for i in range(sections_x)]).T
+        by = xp.array([beta_y**i for i in range(sections_y)]).T
+
+        step_y = xp.einsum(
+            "yk, uk, klbij, by, bu -> yulbij", dft_y, dft_y.conj(), a, by, 1 / by
+        )
+
+        spatial_blocks = xp.einsum(
+            "xl, vl, yulbij, bx, bv -> yxbvuij", dft_x, dft_x.conj(), step_y, bx, 1 / bx
+        )
+    else:
+        step_y = xp.einsum("yk, uk, klbij -> yulbij", dft_y, dft_y.conj(), a)
+
+        spatial_blocks = xp.einsum(
+            "xl, vl, yulbij -> yxbvuij", dft_x, dft_x.conj(), step_y
+        )
+
+    # Reconstruct the final block-matrix layout
+    permuted = xp.transpose(spatial_blocks, (2, 1, 0, 5, 3, 4, 6))
+
+    total_size = sections_x * sections_y * block_size_y
+    return permuted.reshape(batch_size, total_size, total_size)
 
 
 def detransform_circulant(
     a: NDArray,
-    sections_x: int = 1,
-    sections_y: int = 1,
 ) -> NDArray:
     """Inverse transformation of the block diagonal form to the original matrix
     form. This is the inverse of the `transform_circulant` function and uses the
@@ -347,10 +445,6 @@ def detransform_circulant(
     ----------
     a : NDArray
         The matrix to detransform.
-    sections_x : int, optional
-        The number of sections in the x direction, by default 1.
-    sections_y : int, optional
-        The number of sections in the y direction, by default 1.
 
     Returns
     -------
@@ -364,57 +458,11 @@ def detransform_circulant(
             "The input matrix must have 5 dimensions after transformation."
         )
 
-    if a.shape[0] != sections_y:
-        raise ValueError("The first dimension of a must be equal to sections_y.")
-    if a.shape[1] != sections_x:
-        raise ValueError("The second dimension of a must be equal to sections_x.")
-
-    block_size_y = a.shape[-1]
-    block_size_x = block_size_y * a.shape[0]
-    batch_size = a.shape[2]
-
-    idft_x = _get_idft_matrix(sections_x)
-    idft_y = _get_idft_matrix(sections_y)
-
-    # Transform along the y-sections
-    a = xp.einsum("ij, jklmn -> iklmn", idft_y, a)
-
-    # Transform along the x-sections
-    a = xp.einsum("ij, kjlmn -> kilmn", idft_x, a)
-
-    # expand first in the y direction
-    # the temporary has the shape (sections_x, batch_size, block_size_x, block_size_x)
-    tmp = xp.zeros((sections_x, batch_size, block_size_x, block_size_x), dtype=a.dtype)
-    a = a.transpose(1, 2, 3, 0, 4).reshape(
-        sections_x, batch_size, block_size_y, block_size_x
-    )
-
-    for i in range(0, block_size_x, block_size_y):
-        tmp[..., i : i + block_size_y, :] = a
-        # roll the layer
-        a = xp.roll(a, block_size_y, axis=-1)
-
-    # expand first in the x direction
-    tmp = tmp.transpose(1, 2, 0, 3).reshape(
-        batch_size, block_size_x, block_size_x * sections_x
-    )
-    out = xp.zeros(
-        (batch_size, block_size_x * sections_x, block_size_x * sections_x),
-        dtype=a.dtype,
-    )
-
-    for i in range(0, block_size_x * sections_x, block_size_x):
-        out[..., i : i + block_size_x, :] = tmp
-        # roll the layer
-        tmp = xp.roll(tmp, block_size_x, axis=-1)
-
-    return out
+    return _core_detransform(a)
 
 
 def detransform_circulant_vector(
     v: NDArray,
-    sections_x: int,
-    sections_y: int,
 ):
     """Inverse transformation for the eigenvectors of the block diagonal form to
     the original matrix
@@ -426,10 +474,6 @@ def detransform_circulant_vector(
          are assumed to be the section dimensions, the third dimension is the
          batch dimension, the fourth dimension is the block size, and the fifth
          dimension is the number of eigenvalues per block.
-     sections_x : int
-         The number of sections in the x direction.
-     sections_y : int
-         The number of sections in the y direction.
 
      Returns
      -------
@@ -439,6 +483,7 @@ def detransform_circulant_vector(
          dimensions, and the fourth dimension is the number of eigenvalues.
 
     """
+    sections_y, sections_x = v.shape[0], v.shape[1]
 
     idft_x = _get_dft_matrix(sections_x)
     idft_y = _get_dft_matrix(sections_y)
@@ -557,15 +602,13 @@ def transform_phi_circulant(
     beta = betas_y[:, None, :] * betas_x[None, :, :]
     a = a * beta[..., None, None]
 
-    return _2D_fft(a)
+    return _2D_dft(a)
 
 
 def detransform_phi_circulant(
     a: NDArray,
     phase_x: NDArray,
     phase_y: NDArray,
-    sections_x: int = 1,
-    sections_y: int = 1,
 ) -> NDArray:
     """Inverse transformation of the block diagonal form to the original matrix
     form. This is the inverse of the `transform_phi_circulant` function and uses the
@@ -579,10 +622,6 @@ def detransform_phi_circulant(
         The phase shift in the x direction. This is the phase per batch.
     phase_y : NDArray
         The phase shift in the y direction. This is the phase per batch.
-    sections_x : int, optional
-        The number of sections in the x direction, by default 1.
-    sections_y : int, optional
-        The number of sections in the y direction, by default 1.
 
     Returns
     -------
@@ -600,30 +639,13 @@ def detransform_phi_circulant(
     if phase_x.ndim > 1 or phase_y.ndim > 1:
         raise ValueError("phase_x and phase_y must be 1D arrays.")
 
-    out = detransform_circulant(a, sections_x, sections_y)
-
-    block_size_y = a.shape[-1]
-
-    # need to apply the inverse of the phase transformation
-    beta_x = phase_x ** (1 / sections_x)
-    beta_y = phase_y ** (1 / sections_y)
-
-    betas_x = xp.array([beta_x**i for i in range(sections_x)]).T
-    betas_y = xp.array([beta_y**i for i in range(sections_y)]).T
-
-    ones = xp.ones(block_size_y, dtype=betas_x.dtype)
-
-    beta = xp.einsum("bi,bj,k->bijk", betas_x, betas_y, ones).reshape(len(phase_x), -1)
-
-    return (out * beta[..., None]) / beta[..., None, :]
+    return _core_detransform(a, phase_x=phase_x, phase_y=phase_y)
 
 
 def detransform_phi_circulant_vector(
     v: NDArray,
     phase_x: NDArray,
     phase_y: NDArray,
-    sections_x: int,
-    sections_y: int,
 ):
     """Inverse transformation for the eigenvectors of the block diagonal form to
     the original matrix
@@ -639,10 +661,6 @@ def detransform_phi_circulant_vector(
          The phase shift in the x direction. This is the phase per batch.
      phase_y : NDArray
          The phase shift in the y direction. This is the phase per batch.
-     sections_x : int
-         The number of sections in the x direction.
-     sections_y : int
-         The number of sections in the y direction.
 
      Returns
      -------
@@ -652,8 +670,9 @@ def detransform_phi_circulant_vector(
          dimensions, and the fourth dimension is the number of eigenvalues.
 
     """
+    sections_y, sections_x = v.shape[0], v.shape[1]
 
-    v_flat = detransform_circulant_vector(v, sections_x, sections_y)
+    v_flat = detransform_circulant_vector(v)
 
     block_size_y = v.shape[-2]
 

--- a/src/qttools/toeplitz/circulant.py
+++ b/src/qttools/toeplitz/circulant.py
@@ -411,6 +411,52 @@ def detransform_circulant(
     return out
 
 
+def detransform_circulant_vector(
+    v: NDArray,
+    sections_x: int,
+    sections_y: int,
+):
+    """Inverse transformation for the eigenvectors of the block diagonal form to
+    the original matrix
+
+     Parameters
+     ----------
+     v : NDArray
+         The eigenvectors in the block diagonal form. The first two dimensions
+         are assumed to be the section dimensions, the third dimension is the
+         batch dimension, the fourth dimension is the block size, and the fifth
+         dimension is the number of eigenvalues per block.
+     sections_x : int
+         The number of sections in the x direction.
+     sections_y : int
+         The number of sections in the y direction.
+
+     Returns
+     -------
+     NDArray
+         The eigenvectors in the original matrix form. The first dimension is the
+         batch dimension, the second and third dimensions are the original matrix
+         dimensions, and the fourth dimension is the number of eigenvalues.
+
+    """
+
+    idft_x = _get_dft_matrix(sections_x)
+    idft_y = _get_dft_matrix(sections_y)
+
+    batch_size = v.shape[2]
+    block_size = v.shape[3]
+    eigenvalues_per_block = v.shape[4]
+
+    v_expanded = xp.einsum("yk, xj, kjbie -> bxyikje", idft_y, idft_x, v)
+
+    N_total = sections_x * sections_y * block_size
+    total_eigenvectors = sections_x * sections_y * eigenvalues_per_block
+
+    v_flat = v_expanded.reshape(batch_size, N_total, total_eigenvectors)
+
+    return v_flat
+
+
 def transform_phi_circulant(
     a: NDArray,
     phase_x: NDArray,
@@ -570,3 +616,56 @@ def detransform_phi_circulant(
     beta = xp.einsum("bi,bj,k->bijk", betas_x, betas_y, ones).reshape(len(phase_x), -1)
 
     return (out * beta[..., None]) / beta[..., None, :]
+
+
+def detransform_phi_circulant_vector(
+    v: NDArray,
+    phase_x: NDArray,
+    phase_y: NDArray,
+    sections_x: int,
+    sections_y: int,
+):
+    """Inverse transformation for the eigenvectors of the block diagonal form to
+    the original matrix
+
+     Parameters
+     ----------
+     v : NDArray
+         The eigenvectors in the block diagonal form. The first two dimensions
+         are assumed to be the section dimensions, the third dimension is the
+         batch dimension, the fourth dimension is the block size, and the fifth
+         dimension is the number of eigenvalues per block.
+     phase_x : NDArray
+         The phase shift in the x direction. This is the phase per batch.
+     phase_y : NDArray
+         The phase shift in the y direction. This is the phase per batch.
+     sections_x : int
+         The number of sections in the x direction.
+     sections_y : int
+         The number of sections in the y direction.
+
+     Returns
+     -------
+     NDArray
+         The eigenvectors in the original matrix form. The first dimension is the
+         batch dimension, the second and third dimensions are the original matrix
+         dimensions, and the fourth dimension is the number of eigenvalues.
+
+    """
+
+    v_flat = detransform_circulant_vector(v, sections_x, sections_y)
+
+    block_size_y = v.shape[-2]
+
+    # need to apply the inverse of the phase transformation
+    beta_x = phase_x ** (1 / sections_x)
+    beta_y = phase_y ** (1 / sections_y)
+
+    betas_x = xp.array([beta_x**i for i in range(sections_x)]).T
+    betas_y = xp.array([beta_y**i for i in range(sections_y)]).T
+
+    ones = xp.ones(block_size_y, dtype=betas_x.dtype)
+
+    beta = xp.einsum("bi,bj,k->bijk", betas_x, betas_y, ones).reshape(len(phase_x), -1)
+
+    return v_flat * beta[..., None]

--- a/src/qttools/toeplitz/circulant.py
+++ b/src/qttools/toeplitz/circulant.py
@@ -5,6 +5,146 @@ from qttools import NDArray, xp
 from qttools.datastructures.dsdbsparse import _block_view
 
 
+def _make_1D_block_circulant(
+    a: NDArray,
+    sections: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections != 0:
+        raise ValueError("The last dimension of a must be divisible by sections.")
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size = a.shape[-1] // sections
+    # Take the first block-row (top n rows)
+    block_layer = a[..., :block_size, :]
+    blocks = xp.split(block_layer, sections, axis=-1)
+
+    matrix = xp.zeros_like(a)
+    for i in range(sections):
+        shifted_blocks = blocks[-i:] + blocks[:-i]
+        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
+            shifted_blocks, axis=-1
+        )
+
+    return matrix
+
+
+def _make_2D_block_circulant(
+    a: NDArray,
+    sections_x: int,
+    sections_y: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+    if a.shape[-1] % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+    if a.shape[-1] % (sections_x * sections_y) != 0:
+        raise ValueError(
+            "The last dimension of a must be divisible by the section product."
+        )
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size_x = a.shape[-1] // sections_x
+
+    # make first circulant in the y direction
+    for i in range(0, a.shape[-1], block_size_x):
+        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_circulant(
+            a[..., :block_size_x, i : i + block_size_x],
+            sections=sections_y,
+        )
+
+    return _make_1D_block_circulant(a, sections=sections_x)
+
+
+def _make_1D_block_phi_circulant(
+    a: NDArray,
+    phase: NDArray,
+    sections: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections != 0:
+        raise ValueError("The last dimension of a must be divisible by sections.")
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size = a.shape[-1] // sections
+    # Take the first block-row (top n rows)
+    block_layer = a[..., :block_size, :]
+    blocks = xp.split(block_layer, sections, axis=-1)
+
+    matrix = xp.zeros_like(a)
+    for i in range(sections):
+        if i == 0:
+            phased_blocks = blocks[-i:]
+        else:
+            phased_blocks = [
+                phase[:, *([None] * (len(block.shape) - 1))] * block
+                for block in blocks[-i:]
+            ]
+
+        shifted_blocks = phased_blocks + blocks[:-i]
+        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
+            shifted_blocks, axis=-1
+        )
+
+    return matrix
+
+
+def _make_2D_block_phi_circulant(
+    a: NDArray,
+    phase_x: NDArray,
+    phase_y: NDArray,
+    sections_x: int,
+    sections_y: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+    if a.shape[-1] % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+    if a.shape[-1] % (sections_x * sections_y) != 0:
+        raise ValueError(
+            "The last dimension of a must be divisible by the section product."
+        )
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size_x = a.shape[-1] // sections_x
+
+    # make first circulant in the y direction
+    for i in range(0, a.shape[-1], block_size_x):
+        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_phi_circulant(
+            a[..., :block_size_x, i : i + block_size_x],
+            phase_y,
+            sections=sections_y,
+        )
+
+    return _make_1D_block_phi_circulant(a, phase_x, sections=sections_x)
+
+
 def check_circulant(a: NDArray, sections: int) -> bool:
     """Check if a matrix is block circulant with the given number of sections.
 
@@ -273,8 +413,8 @@ def detransform_circulant(
 
 def transform_phi_circulant(
     a: NDArray,
-    phase_x: complex = 1,
-    phase_y: complex = 1,
+    phase_x: NDArray,
+    phase_y: NDArray,
     sections_x: int = 1,
     sections_y: int = 1,
 ):
@@ -316,10 +456,10 @@ def transform_phi_circulant(
         The matrix to transform. The last two dimensions are assumed to be
         square and the last dimension is assumed to be divisible by sections_x
         and sections_y.
-    phase_x : complex, optional
-        The phase shift in the x direction, by default 1.
-    phase_y : complex, optional
-        The phase shift in the y direction, by default 1.
+    phase_x : NDArray
+        The phase shift in the x direction. This is the phase per batch.
+    phase_y : NDArray
+        The phase shift in the y direction. This is the phase per batch.
     sections_x : int, optional 
         The number of sections in the x direction, by default 1.
     sections_y : int, optional
@@ -337,6 +477,15 @@ def transform_phi_circulant(
 
     if a.shape[-1] % sections_x != 0:
         raise ValueError("The last dimension of a must be divisible by sections_x.")
+
+    if not isinstance(phase_x, xp.ndarray):
+        raise TypeError("phase_x must be an array.")
+
+    if not isinstance(phase_y, xp.ndarray):
+        raise TypeError("phase_y must be an array.")
+
+    if phase_x.ndim > 1 or phase_y.ndim > 1:
+        raise ValueError("phase_x and phase_y must be 1D arrays.")
 
     block_size_x = a.shape[-1] // sections_x
 
@@ -359,16 +508,16 @@ def transform_phi_circulant(
     betas_x = xp.array([beta_x**i for i in range(sections_x)])
     betas_y = xp.array([beta_y**i for i in range(sections_y)])
 
-    beta = betas_y[:, None] * betas_x[None, :]
-    a = a * beta[..., None, None, None]
+    beta = betas_y[:, None, :] * betas_x[None, :, :]
+    a = a * beta[..., None, None]
 
     return _2D_fft(a)
 
 
 def detransform_phi_circulant(
     a: NDArray,
-    phase_x: complex = 1,
-    phase_y: complex = 1,
+    phase_x: NDArray,
+    phase_y: NDArray,
     sections_x: int = 1,
     sections_y: int = 1,
 ) -> NDArray:
@@ -380,10 +529,10 @@ def detransform_phi_circulant(
     ----------
     a : NDArray
         The matrix to detransform.
-    phase_x : complex, optional
-        The phase shift in the x direction, by default 1.
-    phase_y : complex, optional
-        The phase shift in the y direction, by default 1.
+    phase_x : NDArray
+        The phase shift in the x direction. This is the phase per batch.
+    phase_y : NDArray
+        The phase shift in the y direction. This is the phase per batch.
     sections_x : int, optional
         The number of sections in the x direction, by default 1.
     sections_y : int, optional
@@ -395,17 +544,29 @@ def detransform_phi_circulant(
         The original matrix before transformation.
 
     """
-    block_size_y = a.shape[-1]
+
+    if not isinstance(phase_x, xp.ndarray):
+        raise TypeError("phase_x must be an array.")
+
+    if not isinstance(phase_y, xp.ndarray):
+        raise TypeError("phase_y must be an array.")
+
+    if phase_x.ndim > 1 or phase_y.ndim > 1:
+        raise ValueError("phase_x and phase_y must be 1D arrays.")
 
     out = detransform_circulant(a, sections_x, sections_y)
+
+    block_size_y = a.shape[-1]
 
     # need to apply the inverse of the phase transformation
     beta_x = phase_x ** (1 / sections_x)
     beta_y = phase_y ** (1 / sections_y)
 
-    betas_x = xp.array([beta_x**i for i in range(sections_x)])
-    betas_y = xp.array([beta_y**i for i in range(sections_y)])
+    betas_x = xp.array([beta_x**i for i in range(sections_x)]).T
+    betas_y = xp.array([beta_y**i for i in range(sections_y)]).T
 
-    beta = xp.kron(betas_x, xp.kron(betas_y, xp.ones(block_size_y)))
+    ones = xp.ones(block_size_y, dtype=betas_x.dtype)
 
-    return (out * beta[None, :, None]) / beta[None, None, :]
+    beta = xp.einsum("bi,bj,k->bijk", betas_x, betas_y, ones).reshape(len(phase_x), -1)
+
+    return (out * beta[..., None]) / beta[..., None, :]

--- a/src/quatrex/device/inputs.py
+++ b/src/quatrex/device/inputs.py
@@ -122,11 +122,12 @@ def create_coordinate_grid(
     return grid
 
 
-def _construct_transport_cell(
+def construct_transport_cell(
     matrix_dict: dict,
     transport_cell_size: int,
     transport_ind: int,
     shift: tuple,
+    key_assumption: str | None = None,
 ) -> NDArray:
     """Constructs a transport block from the unit cell.
     This expand the unit cell matrix into a block matrix for the transport cell,
@@ -142,12 +143,18 @@ def _construct_transport_cell(
     transport_ind : int
         Direction of transport. Can be 0, 1, 2.
     shift : tuple
-        Shift in the transport cell system.
-        It is expected to be 0 / transport_cell_size / -transport_cell_size
-        in the transport direction and arbitrary in the other directions.
-        Shift of (0,0,0) constructs the diagonal transport cell.
-        Shift of (2,2,2) constructs the second off-diagonal transport cell
-        for the connection (2,2) between the center matrix and the periodic image.
+        Shift in the transport cell system. It is expected to be 0 /
+        transport_cell_size / -transport_cell_size in the transport direction
+        and arbitrary in the other directions. Shift of (0,0,0) constructs the
+        diagonal transport cell. Shift of (2,2,2) constructs the second
+        off-diagonal transport cell for the connection (2,2) between the center
+        matrix and the periodic image.
+    key_assumption : str or None
+        Assumption on the keys in the matrix_dict. If it is None, it is assumed
+        that all keys are present. If it is "upper", it is assumed that only the
+        upper triangular part of the matrices are present, and the lower
+        triangular part can be obtained by conjugate transpose. If it is "half",
+        it is assumed that the full matrix is present for half the keys.
 
     Returns
     -------
@@ -161,9 +168,14 @@ def _construct_transport_cell(
             f"Shift in the transport direction must be 0, transport_cell_size, or -transport_cell_size. "
             f"Got shift={shift} and transport_cell_size={transport_cell_size}."
         )
+    if key_assumption not in [None, "upper", "half"]:
+        raise ValueError(
+            f"key_assumption must be None, 'upper', or 'half'. Got {key_assumption}."
+        )
 
     unit_cell_shape = matrix_dict[(0, 0, 0)].shape
     unit_cell_dtype = matrix_dict[(0, 0, 0)].dtype
+    zero_block = xp.zeros(unit_cell_shape, unit_cell_dtype)
 
     rows = []
     for r_i in range(transport_cell_size):
@@ -172,23 +184,26 @@ def _construct_transport_cell(
 
             coord = list(shift)
             coord[transport_ind] += r_j - r_i
+
             coord = tuple(int(i) for i in coord)
+            coord_flipped = tuple(-i for i in coord)
 
-            flipped_coord = tuple(-int(i) for i in coord)
+            block = matrix_dict.get(coord)
+            block_flipped = matrix_dict.get(coord_flipped)
 
-            if coord in matrix_dict:
-                block = matrix_dict[coord]
-                block_flipped = matrix_dict[flipped_coord]
-                block = block + xp.triu(block_flipped, k=1).conj().T
+            if block is not None:
+                if key_assumption == "upper" and block_flipped is not None:
+                    block = block + xp.triu(block_flipped, k=1).conj().swapaxes(-2, -1)
+            elif key_assumption == "half" and block_flipped is not None:
+                block = block_flipped.conj().swapaxes(-2, -1)
             else:
-                block = xp.zeros(unit_cell_shape, unit_cell_dtype)
+                block = zero_block
 
             row.append(block)
-        rows.append(xp.hstack(row))
-    cell = xp.vstack(rows)
-    if shift[transport_ind] == 0:
-        cell = xp.triu(cell)
-    return cell
+
+        rows.append(xp.concatenate(row, axis=-1))
+
+    return xp.concatenate(rows, axis=-2)
 
 
 def _expand_tight_binding_matrix(
@@ -283,16 +298,20 @@ def _expand_tight_binding_matrix(
     # Expand and convert to sparse matrices.
     # TODO: assumes matrices are dense for now
     blocks = [
-        sparse.coo_matrix(
-            _construct_transport_cell(
-                matrix_dict=matrix_dict,
-                transport_cell_size=transport_cell_size,
-                transport_ind=transport_ind,
-                shift=shift,
-            )
+        construct_transport_cell(
+            matrix_dict=matrix_dict,
+            transport_cell_size=transport_cell_size,
+            transport_ind=transport_ind,
+            shift=shift,
+            key_assumption="upper",
         )
         for shift in block_inds
     ]
+    blocks = [
+        xp.triu(block) if shift[transport_ind] == 0 else block
+        for block, shift in zip(blocks, block_inds)
+    ]
+    blocks = [sparse.coo_matrix(block) for block in blocks]
 
     # Canoncialize the sparse matrices.
     for block in blocks:

--- a/tests/qttools/boundary_conditions/obc/conftest.py
+++ b/tests/qttools/boundary_conditions/obc/conftest.py
@@ -20,7 +20,9 @@ BLOCK_SIZE = [
 
 BLOCK_SECTIONS = [
     pytest.param(1, id="no-subblocks"),
+    pytest.param(2, id="two-subblocks"),
     pytest.param(3, id="three-subblocks"),
+    pytest.param(4, id="four-subblocks"),
 ]
 
 BATCH_SIZE = [
@@ -54,6 +56,18 @@ def block_size(request: pytest.FixtureRequest) -> int:
 
 @pytest.fixture(params=BLOCK_SECTIONS)
 def block_sections(request: pytest.FixtureRequest) -> int:
+    """Returns the number of block sections."""
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_SECTIONS)
+def block_sections_x(request: pytest.FixtureRequest) -> int:
+    """Returns the number of block sections."""
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_SECTIONS)
+def block_sections_y(request: pytest.FixtureRequest) -> int:
     """Returns the number of block sections."""
     return request.param
 

--- a/tests/qttools/boundary_conditions/obc/test_nevp.py
+++ b/tests/qttools/boundary_conditions/obc/test_nevp.py
@@ -111,9 +111,7 @@ def test_circulant(
 
     # upscale eigenvalues
     ws = ws.transpose(2, 0, 1, 3).reshape(batch_size, -1)
-    vs = detransform_circulant_vector(
-        vs, sections_x=block_sections_x, sections_y=block_sections_y
-    )
+    vs = detransform_circulant_vector(vs)
 
     _check_residuals(a_xx, ws, vs)
 
@@ -171,8 +169,6 @@ def test_phi_circulant(
         vs,
         phase_x=phase_x,
         phase_y=phase_y,
-        sections_x=block_sections_x,
-        sections_y=block_sections_y,
     )
 
     _check_residuals(a_xx, ws, vs)

--- a/tests/qttools/boundary_conditions/obc/test_nevp.py
+++ b/tests/qttools/boundary_conditions/obc/test_nevp.py
@@ -15,10 +15,9 @@ from qttools.toeplitz.circulant import (
 )
 
 
-def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
-    """Tests that the subspace NEVP solver returns the correct result."""
-    ws, vs = nevp(a_xx)
-
+def _check_residuals(a_xx: tuple[NDArray, ...], ws: NDArray, vs: NDArray) -> None:
+    """Checks that the residuals of the eigenvalue problem are small for the
+    computed eigenvalues and eigenvectors."""
     a_ji, a_ii, a_ij = a_xx
     residuals = []
     for e in range(ws.shape[0]):
@@ -43,6 +42,13 @@ def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
     assert not xp.all(spurious_mask)
 
     assert residuals[~spurious_mask].max() < 1e-5
+
+
+def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
+    """Tests that the subspace NEVP solver returns the correct result."""
+    ws, vs = nevp(a_xx)
+
+    _check_residuals(a_xx, ws, vs)
 
 
 @pytest.mark.parametrize("reduce", [False, True])
@@ -68,30 +74,7 @@ def test_full(a_xx: tuple[NDArray, ...], reduce: bool, provide_sparsity: bool):
     full_nevp = Full(a_xx_sparsity=a_xx_sparsity, reduce=reduce)
     ws, vs = full_nevp(a_xx)
 
-    a_ji, a_ii, a_ij = a_xx
-    residuals = []
-    for e in range(ws.shape[0]):
-        for k in range(ws.shape[1]):
-            w = ws[e, k]
-            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
-            with np.errstate(divide="ignore", invalid="ignore"):
-                residuals.append(
-                    xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
-                    / xp.linalg.norm(w)
-                )
-
-    residuals = xp.nan_to_num(xp.array(residuals))
-
-    # Filter outlier eigenmodes (robust Z-score method).
-    median = xp.median(residuals)
-    median_abs_deviation = xp.median(xp.abs(residuals - median))
-    z_scores = 0.6745 * (residuals - median) / median_abs_deviation
-    spurious_mask = xp.abs(z_scores) > 30  # Very generous threshold.
-
-    # assert some eigenvalues were found
-    assert not xp.all(spurious_mask)
-
-    assert residuals[~spurious_mask].max() < 1e-5
+    _check_residuals(a_xx, ws, vs)
 
 
 def test_circulant(
@@ -132,30 +115,7 @@ def test_circulant(
         vs, sections_x=block_sections_x, sections_y=block_sections_y
     )
 
-    a_ji, a_ii, a_ij = a_xx
-    residuals = []
-    for e in range(ws.shape[0]):
-        for k in range(ws.shape[1]):
-            w = ws[e, k]
-            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
-            with np.errstate(divide="ignore", invalid="ignore"):
-                residuals.append(
-                    xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
-                    / xp.linalg.norm(w)
-                )
-
-    residuals = xp.nan_to_num(xp.array(residuals))
-
-    # Filter outlier eigenmodes (robust Z-score method).
-    median = xp.median(residuals)
-    median_abs_deviation = xp.median(xp.abs(residuals - median))
-    z_scores = 0.6745 * (residuals - median) / median_abs_deviation
-    spurious_mask = xp.abs(z_scores) > 30  # Very generous threshold.
-
-    # assert some eigenvalues were found
-    assert not xp.all(spurious_mask)
-
-    assert residuals[~spurious_mask].max() < 1e-5
+    _check_residuals(a_xx, ws, vs)
 
 
 def test_phi_circulant(
@@ -215,27 +175,4 @@ def test_phi_circulant(
         sections_y=block_sections_y,
     )
 
-    a_ji, a_ii, a_ij = a_xx
-    residuals = []
-    for e in range(ws.shape[0]):
-        for k in range(ws.shape[1]):
-            w = ws[e, k]
-            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
-            with np.errstate(divide="ignore", invalid="ignore"):
-                residuals.append(
-                    xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
-                    / xp.linalg.norm(w)
-                )
-
-    residuals = xp.nan_to_num(xp.array(residuals))
-
-    # Filter outlier eigenmodes (robust Z-score method).
-    median = xp.median(residuals)
-    median_abs_deviation = xp.median(xp.abs(residuals - median))
-    z_scores = 0.6745 * (residuals - median) / median_abs_deviation
-    spurious_mask = xp.abs(z_scores) > 30  # Very generous threshold.
-
-    # assert some eigenvalues were found
-    assert not xp.all(spurious_mask)
-
-    assert residuals[~spurious_mask].max() < 1e-5
+    _check_residuals(a_xx, ws, vs)

--- a/tests/qttools/boundary_conditions/obc/test_nevp.py
+++ b/tests/qttools/boundary_conditions/obc/test_nevp.py
@@ -5,6 +5,14 @@ import pytest
 
 from qttools import NDArray, sparse, xp
 from qttools.nevp import NEVP, Full
+from qttools.toeplitz.circulant import (
+    _make_2D_block_circulant,
+    _make_2D_block_phi_circulant,
+    detransform_circulant_vector,
+    detransform_phi_circulant_vector,
+    transform_circulant,
+    transform_phi_circulant,
+)
 
 
 def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
@@ -16,7 +24,7 @@ def test_nevp(a_xx: tuple[NDArray, ...], nevp: NEVP):
     for e in range(ws.shape[0]):
         for k in range(ws.shape[1]):
             w = ws[e, k]
-            v = vs[e, :, k] / xp.linalg.norm(vs[0, :, k])
+            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
             with np.errstate(divide="ignore", invalid="ignore"):
                 residuals.append(
                     xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
@@ -65,7 +73,154 @@ def test_full(a_xx: tuple[NDArray, ...], reduce: bool, provide_sparsity: bool):
     for e in range(ws.shape[0]):
         for k in range(ws.shape[1]):
             w = ws[e, k]
-            v = vs[e, :, k] / xp.linalg.norm(vs[0, :, k])
+            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
+            with np.errstate(divide="ignore", invalid="ignore"):
+                residuals.append(
+                    xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
+                    / xp.linalg.norm(w)
+                )
+
+    residuals = xp.nan_to_num(xp.array(residuals))
+
+    # Filter outlier eigenmodes (robust Z-score method).
+    median = xp.median(residuals)
+    median_abs_deviation = xp.median(xp.abs(residuals - median))
+    z_scores = 0.6745 * (residuals - median) / median_abs_deviation
+    spurious_mask = xp.abs(z_scores) > 30  # Very generous threshold.
+
+    # assert some eigenvalues were found
+    assert not xp.all(spurious_mask)
+
+    assert residuals[~spurious_mask].max() < 1e-5
+
+
+def test_circulant(
+    a_xx: tuple[NDArray, ...], block_sections_x: int, block_sections_y: int
+):
+    """Tests that the full NEVP solver returns the correct result for block-circulant matrices."""
+
+    batch_size = a_xx[0].shape[0]
+    block_size = a_xx[0].shape[-1]
+
+    if block_size % block_sections_x != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % block_sections_y != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % (block_sections_x * block_sections_y) != 0:
+        pytest.skip("The block size must be divisible by the section product.")
+
+    a_xx = tuple(
+        _make_2D_block_circulant(
+            a_x, sections_x=block_sections_x, sections_y=block_sections_y
+        )
+        for a_x in a_xx
+    )
+
+    a_xx_tmp = tuple(
+        transform_circulant(
+            a_x, sections_x=block_sections_x, sections_y=block_sections_y
+        )
+        for a_x in a_xx
+    )
+
+    full_nevp = Full()
+    ws, vs = full_nevp(a_xx_tmp)
+
+    # upscale eigenvalues
+    ws = ws.transpose(2, 0, 1, 3).reshape(batch_size, -1)
+    vs = detransform_circulant_vector(
+        vs, sections_x=block_sections_x, sections_y=block_sections_y
+    )
+
+    a_ji, a_ii, a_ij = a_xx
+    residuals = []
+    for e in range(ws.shape[0]):
+        for k in range(ws.shape[1]):
+            w = ws[e, k]
+            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
+            with np.errstate(divide="ignore", invalid="ignore"):
+                residuals.append(
+                    xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)
+                    / xp.linalg.norm(w)
+                )
+
+    residuals = xp.nan_to_num(xp.array(residuals))
+
+    # Filter outlier eigenmodes (robust Z-score method).
+    median = xp.median(residuals)
+    median_abs_deviation = xp.median(xp.abs(residuals - median))
+    z_scores = 0.6745 * (residuals - median) / median_abs_deviation
+    spurious_mask = xp.abs(z_scores) > 30  # Very generous threshold.
+
+    # assert some eigenvalues were found
+    assert not xp.all(spurious_mask)
+
+    assert residuals[~spurious_mask].max() < 1e-5
+
+
+def test_phi_circulant(
+    a_xx: tuple[NDArray, ...], block_sections_x: int, block_sections_y: int
+):
+    """Tests that the full NEVP solver returns the correct result for block-phi-circulant matrices."""
+
+    batch_size = a_xx[0].shape[0]
+    block_size = a_xx[0].shape[-1]
+
+    if block_size % block_sections_x != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % block_sections_y != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % (block_sections_x * block_sections_y) != 0:
+        pytest.skip("The block size must be divisible by the section product.")
+
+    phase_x = xp.array(
+        [xp.exp(i * 2j * xp.pi / block_sections_x) for i in range(batch_size)]
+    )
+    phase_y = xp.array(
+        [xp.exp(i * 2j * xp.pi / block_sections_y) for i in range(batch_size)]
+    )
+
+    a_xx = tuple(
+        _make_2D_block_phi_circulant(
+            a_x,
+            phase_x=phase_x,
+            phase_y=phase_y,
+            sections_x=block_sections_x,
+            sections_y=block_sections_y,
+        )
+        for a_x in a_xx
+    )
+
+    a_xx_tmp = tuple(
+        transform_phi_circulant(
+            a_x,
+            phase_x=phase_x,
+            phase_y=phase_y,
+            sections_x=block_sections_x,
+            sections_y=block_sections_y,
+        )
+        for a_x in a_xx
+    )
+
+    full_nevp = Full()
+    ws, vs = full_nevp(a_xx_tmp)
+
+    # upscale eigenvalues
+    ws = ws.transpose(2, 0, 1, 3).reshape(batch_size, -1)
+    vs = detransform_phi_circulant_vector(
+        vs,
+        phase_x=phase_x,
+        phase_y=phase_y,
+        sections_x=block_sections_x,
+        sections_y=block_sections_y,
+    )
+
+    a_ji, a_ii, a_ij = a_xx
+    residuals = []
+    for e in range(ws.shape[0]):
+        for k in range(ws.shape[1]):
+            w = ws[e, k]
+            v = vs[e, :, k] / xp.linalg.norm(vs[e, :, k])
             with np.errstate(divide="ignore", invalid="ignore"):
                 residuals.append(
                     xp.linalg.norm((a_ji[e] / w + a_ii[e] + a_ij[e] * w) @ v)

--- a/tests/qttools/boundary_conditions/obc/test_spectral.py
+++ b/tests/qttools/boundary_conditions/obc/test_spectral.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
+import pytest
 
 from qttools import NDArray, xp
 from qttools.boundary_conditions.obc import OBCSystem, Spectral
@@ -238,3 +239,49 @@ def test_compute_dE_dk(
             dEk_dk_ref[i, j] = phi_left.conj().T @ a @ phi_right
 
     assert xp.allclose(dEk_dk, dEk_dk_ref)
+
+
+def test_injected(
+    a_xx: tuple[NDArray, ...],
+    nevp: NEVP,
+    block_sections: int,
+):
+    """Tests that the OBC return the correct result when injected modes are
+    requested."""
+
+    # skip the test if `Beyn` is used
+    if nevp.__class__.__name__ == "Beyn":
+        pytest.skip(
+            "Beyn is very sensitive and the test fails for the carbon nanotube example."
+            "We need to find a better example to test the injection vector calculation with Beyn."
+        )
+
+    spectral = Spectral(
+        nevp=nevp,
+        block_sections=block_sections,
+        residual_tolerance=1e-1,
+        max_decay=20,
+    )
+    a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
+    x_ii, phi_surfaces = spectral(
+        a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact="", return_injected=True
+    )
+
+    assert xp.all(
+        (
+            xp.linalg.norm(
+                x_ii - xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij), axis=(-1, -2)
+            )
+            / xp.linalg.norm(x_ii, axis=(-1, -2))
+        )
+        < 5e-3
+    )
+
+    # TODO: There is no simple way to check the correctnes of the injected
+    # modes, but we can check that the code produces the same injected modes in
+    # a batch and non-batch setting.
+    for i in range(a_ii.shape[0]):
+        __, phi_surface = spectral(
+            a_ii=a_ii[i], a_ij=a_ij[i], a_ji=a_ji[i], contact="", return_injected=True
+        )
+        assert xp.allclose(phi_surface, phi_surfaces[i])

--- a/tests/qttools/boundary_conditions/obc/test_spectral.py
+++ b/tests/qttools/boundary_conditions/obc/test_spectral.py
@@ -174,6 +174,9 @@ def test_upscaling(
 ):
     """Tests that the eigenmode upscaling works."""
 
+    if block_size % block_sections != 0:
+        pytest.skip("block_size must be divisible by block_sections")
+
     spectral = Spectral(nevp=nevp, block_sections=block_sections)
 
     rng = xp.random.default_rng()

--- a/tests/qttools/toeplitz/conftest.py
+++ b/tests/qttools/toeplitz/conftest.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
+
+import pytest
+
+BLOCK_SIZE = [
+    pytest.param(21, id="21x21"),
+    pytest.param(18, id="18x18"),
+    pytest.param(32, id="21x21"),
+]
+
+BLOCK_SECTIONS = [
+    pytest.param(1, id="no-subblocks"),
+    pytest.param(2, id="no-subblocks"),
+    pytest.param(3, id="three-subblocks"),
+    pytest.param(4, id="three-subblocks"),
+]
+
+BATCH_SIZE = [
+    pytest.param(1, id="single-batch"),
+    pytest.param(3, id="three-batches"),
+]
+
+
+@pytest.fixture(params=BLOCK_SIZE)
+def block_size(request: pytest.FixtureRequest) -> int:
+    """Returns the block size."""
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_SECTIONS)
+def block_sections(request: pytest.FixtureRequest) -> int:
+    """Returns the number of block sections."""
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_SECTIONS)
+def block_sections_x(request: pytest.FixtureRequest) -> int:
+    """Returns the number of block sections."""
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_SECTIONS)
+def block_sections_y(request: pytest.FixtureRequest) -> int:
+    """Returns the number of block sections."""
+    return request.param
+
+
+@pytest.fixture(params=BATCH_SIZE)
+def batch_size(request: pytest.FixtureRequest) -> int:
+    """Returns the block size."""
+    return request.param

--- a/tests/qttools/toeplitz/test_circulant.py
+++ b/tests/qttools/toeplitz/test_circulant.py
@@ -4,6 +4,8 @@ import pytest
 
 from qttools import xp
 from qttools.toeplitz.circulant import (
+    _2D_dft,
+    _2D_idft,
     _get_dft_matrix,
     _get_idft_matrix,
     _make_1D_block_circulant,
@@ -36,6 +38,18 @@ def test_dft_matrix(block_sections: int):
     assert xp.allclose(W_inv.conj().T @ W_inv, xp.eye(block_sections))
 
 
+def test_2D_dft(block_sections_x: int, block_sections_y: int):
+    """Test `_2D_dft` and `_2D_idft`."""
+
+    rng = xp.random.default_rng(seed=0)
+    x = rng.random((block_sections_y, block_sections_x)) + 1j * rng.random(
+        (block_sections_y, block_sections_x)
+    )
+    x_dft = _2D_dft(x)
+    x_idft = _2D_idft(x_dft)
+    assert xp.allclose(x, x_idft)
+
+
 def test_transform_1D_circulant(batch_size: int, block_size: int, block_sections: int):
     """Test the transformation of a 1D block circulant matrix to block diagonal form."""
 
@@ -59,7 +73,7 @@ def test_transform_1D_circulant(batch_size: int, block_size: int, block_sections
 
     a_diagonal = transform_circulant(a_circulant, sections_x=block_sections)
 
-    a_test = detransform_circulant(a_diagonal, sections_x=block_sections)
+    a_test = detransform_circulant(a_diagonal)
 
     assert xp.allclose(a_circulant, a_test)
 
@@ -94,9 +108,7 @@ def test_transform_2D_circulant(
         a_circulant, sections_x=block_sections_x, sections_y=block_sections_y
     )
 
-    a_test = detransform_circulant(
-        a_diagonal, sections_x=block_sections_x, sections_y=block_sections_y
-    )
+    a_test = detransform_circulant(a_diagonal)
 
     assert xp.allclose(a_circulant, a_test)
 
@@ -150,8 +162,6 @@ def test_transform_2D_phi_circulant(
         a_diagonal,
         phase_x=phase_x,
         phase_y=phase_y,
-        sections_x=block_sections_x,
-        sections_y=block_sections_y,
     )
 
     assert xp.allclose(a_circulant, a_test)

--- a/tests/qttools/toeplitz/test_circulant.py
+++ b/tests/qttools/toeplitz/test_circulant.py
@@ -2,153 +2,19 @@
 
 import pytest
 
-from qttools import NDArray, xp
+from qttools import xp
 from qttools.toeplitz.circulant import (
     _get_dft_matrix,
     _get_idft_matrix,
+    _make_1D_block_circulant,
+    _make_2D_block_circulant,
+    _make_2D_block_phi_circulant,
     check_circulant,
     detransform_circulant,
     detransform_phi_circulant,
     transform_circulant,
     transform_phi_circulant,
 )
-
-
-def _make_1D_block_circulant(
-    a: NDArray,
-    sections: int,
-) -> NDArray:
-    """Helper function to transform a matrix into a block circulant matrix with
-    the given number of sections."""
-
-    if a.shape[-1] % sections != 0:
-        raise ValueError("The last dimension of a must be divisible by sections.")
-
-    if a.shape[-2] != a.shape[-1]:
-        raise ValueError(
-            "The second to last dimension of a must be equal to the last dimension of a."
-        )
-
-    block_size = a.shape[-1] // sections
-    # Take the first block-row (top n rows)
-    block_layer = a[..., :block_size, :]
-    blocks = xp.split(block_layer, sections, axis=-1)
-
-    matrix = xp.zeros_like(a)
-    for i in range(sections):
-        shifted_blocks = blocks[-i:] + blocks[:-i]
-        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
-            shifted_blocks, axis=-1
-        )
-
-    return matrix
-
-
-def _make_2D_block_circulant(
-    a: NDArray,
-    sections_x: int,
-    sections_y: int,
-) -> NDArray:
-    """Helper function to transform a matrix into a block circulant matrix with
-    the given number of sections."""
-
-    if a.shape[-1] % sections_x != 0:
-        raise ValueError("The last dimension of a must be divisible by sections_x.")
-    if a.shape[-1] % sections_y != 0:
-        raise ValueError("The last dimension of a must be divisible by sections_y.")
-    if a.shape[-1] % (sections_x * sections_y) != 0:
-        raise ValueError(
-            "The last dimension of a must be divisible by the section product."
-        )
-
-    if a.shape[-2] != a.shape[-1]:
-        raise ValueError(
-            "The second to last dimension of a must be equal to the last dimension of a."
-        )
-
-    block_size_x = a.shape[-1] // sections_x
-
-    # make first circulant in the y direction
-    for i in range(0, a.shape[-1], block_size_x):
-        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_circulant(
-            a[..., :block_size_x, i : i + block_size_x],
-            sections=sections_y,
-        )
-
-    return _make_1D_block_circulant(a, sections=sections_x)
-
-
-def _make_1D_block_phi_circulant(
-    a: NDArray,
-    phase: complex,
-    sections: int,
-) -> NDArray:
-    """Helper function to transform a matrix into a block circulant matrix with
-    the given number of sections."""
-
-    if a.shape[-1] % sections != 0:
-        raise ValueError("The last dimension of a must be divisible by sections.")
-
-    if a.shape[-2] != a.shape[-1]:
-        raise ValueError(
-            "The second to last dimension of a must be equal to the last dimension of a."
-        )
-
-    block_size = a.shape[-1] // sections
-    # Take the first block-row (top n rows)
-    block_layer = a[..., :block_size, :]
-    blocks = xp.split(block_layer, sections, axis=-1)
-
-    matrix = xp.zeros_like(a)
-    for i in range(sections):
-        if i == 0:
-            phased_blocks = blocks[-i:]
-        else:
-            phased_blocks = [phase * block for block in blocks[-i:]]
-
-        shifted_blocks = phased_blocks + blocks[:-i]
-        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
-            shifted_blocks, axis=-1
-        )
-
-    return matrix
-
-
-def _make_2D_block_phi_circulant(
-    a: NDArray,
-    phase_x: complex,
-    phase_y: complex,
-    sections_x: int,
-    sections_y: int,
-) -> NDArray:
-    """Helper function to transform a matrix into a block circulant matrix with
-    the given number of sections."""
-
-    if a.shape[-1] % sections_x != 0:
-        raise ValueError("The last dimension of a must be divisible by sections_x.")
-    if a.shape[-1] % sections_y != 0:
-        raise ValueError("The last dimension of a must be divisible by sections_y.")
-    if a.shape[-1] % (sections_x * sections_y) != 0:
-        raise ValueError(
-            "The last dimension of a must be divisible by the section product."
-        )
-
-    if a.shape[-2] != a.shape[-1]:
-        raise ValueError(
-            "The second to last dimension of a must be equal to the last dimension of a."
-        )
-
-    block_size_x = a.shape[-1] // sections_x
-
-    # make first circulant in the y direction
-    for i in range(0, a.shape[-1], block_size_x):
-        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_phi_circulant(
-            a[..., :block_size_x, i : i + block_size_x],
-            phase_y,
-            sections=sections_y,
-        )
-
-    return _make_1D_block_phi_circulant(a, phase_x, sections=sections_x)
 
 
 def test_dft_matrix(block_sections: int):
@@ -257,8 +123,12 @@ def test_transform_2D_phi_circulant(
             (batch_size, block_size, block_size)
         )
 
-    phase_x = xp.exp(2j * xp.pi / block_sections_x)
-    phase_y = xp.exp(2j * xp.pi / block_sections_y)
+    phase_x = xp.array(
+        [xp.exp(i * 2j * xp.pi / block_sections_x) for i in range(batch_size)]
+    )
+    phase_y = xp.array(
+        [xp.exp(i * 2j * xp.pi / block_sections_y) for i in range(batch_size)]
+    )
 
     a_circulant = _make_2D_block_phi_circulant(
         a,

--- a/tests/qttools/toeplitz/test_circulant.py
+++ b/tests/qttools/toeplitz/test_circulant.py
@@ -4,11 +4,13 @@ import pytest
 
 from qttools import NDArray, xp
 from qttools.toeplitz.circulant import (
-    _detransform_matrix,
     _get_dft_matrix,
     _get_idft_matrix,
-    _transform_matrix,
     check_circulant,
+    detransform_circulant,
+    detransform_phi_circulant,
+    transform_circulant,
+    transform_phi_circulant,
 )
 
 
@@ -76,6 +78,79 @@ def _make_2D_block_circulant(
     return _make_1D_block_circulant(a, sections=sections_x)
 
 
+def _make_1D_block_phi_circulant(
+    a: NDArray,
+    phase: complex,
+    sections: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections != 0:
+        raise ValueError("The last dimension of a must be divisible by sections.")
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size = a.shape[-1] // sections
+    # Take the first block-row (top n rows)
+    block_layer = a[..., :block_size, :]
+    blocks = xp.split(block_layer, sections, axis=-1)
+
+    matrix = xp.zeros_like(a)
+    for i in range(sections):
+        if i == 0:
+            phased_blocks = blocks[-i:]
+        else:
+            phased_blocks = [phase * block for block in blocks[-i:]]
+
+        shifted_blocks = phased_blocks + blocks[:-i]
+        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
+            shifted_blocks, axis=-1
+        )
+
+    return matrix
+
+
+def _make_2D_block_phi_circulant(
+    a: NDArray,
+    phase_x: complex,
+    phase_y: complex,
+    sections_x: int,
+    sections_y: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+    if a.shape[-1] % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+    if a.shape[-1] % (sections_x * sections_y) != 0:
+        raise ValueError(
+            "The last dimension of a must be divisible by the section product."
+        )
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size_x = a.shape[-1] // sections_x
+
+    # make first circulant in the y direction
+    for i in range(0, a.shape[-1], block_size_x):
+        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_phi_circulant(
+            a[..., :block_size_x, i : i + block_size_x],
+            phase_y,
+            sections=sections_y,
+        )
+
+    return _make_1D_block_phi_circulant(a, phase_x, sections=sections_x)
+
+
 def test_dft_matrix(block_sections: int):
     """Test the properties of the DFT and IDFT matrices."""
 
@@ -116,9 +191,9 @@ def test_transform_1D_circulant(batch_size: int, block_size: int, block_sections
     if not check_circulant(a_circulant, block_sections):
         raise ValueError("The generated matrix is not block circulant.")
 
-    a_diagonal = _transform_matrix(a_circulant, sections_x=block_sections)
+    a_diagonal = transform_circulant(a_circulant, sections_x=block_sections)
 
-    a_test = _detransform_matrix(a_diagonal, sections_x=block_sections)
+    a_test = detransform_circulant(a_diagonal, sections_x=block_sections)
 
     assert xp.allclose(a_circulant, a_test)
 
@@ -149,12 +224,64 @@ def test_transform_2D_circulant(
         a, sections_x=block_sections_x, sections_y=block_sections_y
     )
 
-    a_diagonal = _transform_matrix(
+    a_diagonal = transform_circulant(
         a_circulant, sections_x=block_sections_x, sections_y=block_sections_y
     )
 
-    a_test = _detransform_matrix(
+    a_test = detransform_circulant(
         a_diagonal, sections_x=block_sections_x, sections_y=block_sections_y
+    )
+
+    assert xp.allclose(a_circulant, a_test)
+
+
+def test_transform_2D_phi_circulant(
+    batch_size: int, block_size: int, block_sections_x: int, block_sections_y: int
+):
+    """Test the transformation of a 2D block phi circulant matrix to block diagonal form."""
+
+    if block_size % block_sections_x != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % block_sections_y != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % (block_sections_x * block_sections_y) != 0:
+        pytest.skip("The block size must be divisible by the section product.")
+
+    rng = xp.random.default_rng(seed=0)
+    if batch_size == 1:
+        a = rng.random((block_size, block_size)) + 1j * rng.random(
+            (block_size, block_size)
+        )
+    else:
+        a = rng.random((batch_size, block_size, block_size)) + 1j * rng.random(
+            (batch_size, block_size, block_size)
+        )
+
+    phase_x = xp.exp(2j * xp.pi / block_sections_x)
+    phase_y = xp.exp(2j * xp.pi / block_sections_y)
+
+    a_circulant = _make_2D_block_phi_circulant(
+        a,
+        phase_x=phase_x,
+        phase_y=phase_y,
+        sections_x=block_sections_x,
+        sections_y=block_sections_y,
+    )
+
+    a_diagonal = transform_phi_circulant(
+        a_circulant,
+        phase_x=phase_x,
+        phase_y=phase_y,
+        sections_x=block_sections_x,
+        sections_y=block_sections_y,
+    )
+
+    a_test = detransform_phi_circulant(
+        a_diagonal,
+        phase_x=phase_x,
+        phase_y=phase_y,
+        sections_x=block_sections_x,
+        sections_y=block_sections_y,
     )
 
     assert xp.allclose(a_circulant, a_test)

--- a/tests/qttools/toeplitz/test_circulant.py
+++ b/tests/qttools/toeplitz/test_circulant.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
+
+import pytest
+
+from qttools import NDArray, xp
+from qttools.toeplitz.circulant import (
+    _detransform_matrix,
+    _get_dft_matrix,
+    _get_idft_matrix,
+    _transform_matrix,
+    check_circulant,
+)
+
+
+def _make_1D_block_circulant(
+    a: NDArray,
+    sections: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections != 0:
+        raise ValueError("The last dimension of a must be divisible by sections.")
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size = a.shape[-1] // sections
+    # Take the first block-row (top n rows)
+    block_layer = a[..., :block_size, :]
+    blocks = xp.split(block_layer, sections, axis=-1)
+
+    matrix = xp.zeros_like(a)
+    for i in range(sections):
+        shifted_blocks = blocks[-i:] + blocks[:-i]
+        matrix[..., i * block_size : (i + 1) * block_size, :] = xp.concatenate(
+            shifted_blocks, axis=-1
+        )
+
+    return matrix
+
+
+def _make_2D_block_circulant(
+    a: NDArray,
+    sections_x: int,
+    sections_y: int,
+) -> NDArray:
+    """Helper function to transform a matrix into a block circulant matrix with
+    the given number of sections."""
+
+    if a.shape[-1] % sections_x != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_x.")
+    if a.shape[-1] % sections_y != 0:
+        raise ValueError("The last dimension of a must be divisible by sections_y.")
+    if a.shape[-1] % (sections_x * sections_y) != 0:
+        raise ValueError(
+            "The last dimension of a must be divisible by the section product."
+        )
+
+    if a.shape[-2] != a.shape[-1]:
+        raise ValueError(
+            "The second to last dimension of a must be equal to the last dimension of a."
+        )
+
+    block_size_x = a.shape[-1] // sections_x
+
+    # make first circulant in the y direction
+    for i in range(0, a.shape[-1], block_size_x):
+        a[..., :block_size_x, i : i + block_size_x] = _make_1D_block_circulant(
+            a[..., :block_size_x, i : i + block_size_x],
+            sections=sections_y,
+        )
+
+    return _make_1D_block_circulant(a, sections=sections_x)
+
+
+def test_dft_matrix(block_sections: int):
+    """Test the properties of the DFT and IDFT matrices."""
+
+    W = _get_dft_matrix(block_sections)
+    W_inv = _get_idft_matrix(block_sections)
+
+    test = W @ W_inv
+    assert xp.allclose(test, xp.eye(block_sections))
+
+    test = W_inv @ W
+    assert xp.allclose(test, xp.eye(block_sections))
+
+    # The DFT matrix should be unitary
+    assert xp.allclose(W @ W.conj().T, xp.eye(block_sections))
+    assert xp.allclose(W.conj().T @ W, xp.eye(block_sections))
+    assert xp.allclose(W_inv @ W_inv.conj().T, xp.eye(block_sections))
+    assert xp.allclose(W_inv.conj().T @ W_inv, xp.eye(block_sections))
+
+
+def test_transform_1D_circulant(batch_size: int, block_size: int, block_sections: int):
+    """Test the transformation of a 1D block circulant matrix to block diagonal form."""
+
+    if block_size % block_sections != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+
+    rng = xp.random.default_rng(seed=0)
+    if batch_size == 1:
+        a = rng.random((block_size, block_size)) + 1j * rng.random(
+            (block_size, block_size)
+        )
+    else:
+        a = rng.random((batch_size, block_size, block_size)) + 1j * rng.random(
+            (batch_size, block_size, block_size)
+        )
+
+    a_circulant = _make_1D_block_circulant(a, block_sections)
+
+    if not check_circulant(a_circulant, block_sections):
+        raise ValueError("The generated matrix is not block circulant.")
+
+    a_diagonal = _transform_matrix(a_circulant, sections_x=block_sections)
+
+    a_test = _detransform_matrix(a_diagonal, sections_x=block_sections)
+
+    assert xp.allclose(a_circulant, a_test)
+
+
+def test_transform_2D_circulant(
+    batch_size: int, block_size: int, block_sections_x: int, block_sections_y: int
+):
+    """Test the transformation of a 2D block circulant matrix to block diagonal form."""
+
+    if block_size % block_sections_x != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % block_sections_y != 0:
+        pytest.skip("The block size must be divisible by the number of block sections.")
+    if block_size % (block_sections_x * block_sections_y) != 0:
+        pytest.skip("The block size must be divisible by the section product.")
+
+    rng = xp.random.default_rng(seed=0)
+    if batch_size == 1:
+        a = rng.random((block_size, block_size)) + 1j * rng.random(
+            (block_size, block_size)
+        )
+    else:
+        a = rng.random((batch_size, block_size, block_size)) + 1j * rng.random(
+            (batch_size, block_size, block_size)
+        )
+
+    a_circulant = _make_2D_block_circulant(
+        a, sections_x=block_sections_x, sections_y=block_sections_y
+    )
+
+    a_diagonal = _transform_matrix(
+        a_circulant, sections_x=block_sections_x, sections_y=block_sections_y
+    )
+
+    a_test = _detransform_matrix(
+        a_diagonal, sections_x=block_sections_x, sections_y=block_sections_y
+    )
+
+    assert xp.allclose(a_circulant, a_test)

--- a/tests/quatrex/device/conftest.py
+++ b/tests/quatrex/device/conftest.py
@@ -17,8 +17,6 @@ def matrix_dict(request: pytest.FixtureRequest) -> NDArray:
 
     matrix_dict = distributed_load(MOS2_EXAMPLE / "hamiltonian.mat")
 
-    matrix_dict = {
-        key: xp.triu(xp.asarray(matrix)) for key, matrix in matrix_dict.items()
-    }
+    matrix_dict = {key: xp.asarray(matrix) for key, matrix in matrix_dict.items()}
 
     return matrix_dict

--- a/tests/quatrex/device/test_inputs.py
+++ b/tests/quatrex/device/test_inputs.py
@@ -5,8 +5,8 @@ import pytest
 
 from qttools import NDArray, xp
 from quatrex.device.inputs import (
-    _construct_transport_cell,
     _expand_tight_binding_matrix,
+    construct_transport_cell,
     create_coordinate_grid,
 )
 
@@ -32,36 +32,59 @@ from quatrex.device.inputs import (
         ),
     ],
 )
+@pytest.mark.parametrize("key_assumption", [None, "upper", "half"])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_construct_transport_cell(
     matrix_dict: dict,
     transport_cell_size: int,
     shift: tuple[int, int, int],
+    key_assumption: str | None,
+    batch_size: int,
 ):
     """Tests the extraction of the transport block from the tight binding matrix."""
 
     # z-direction for transport
     transport_ind = 2
-    test_block = _construct_transport_cell(
-        matrix_dict, transport_cell_size, transport_ind, shift
+
+    # Avoid modifying the orignal one
+    if batch_size > 1:
+        matrix_dict_copy = {
+            key: xp.array([matrix.copy() for _ in range(batch_size)])
+            for key, matrix in matrix_dict.items()
+        }
+    else:
+        matrix_dict_copy = {key: matrix.copy() for key, matrix in matrix_dict.items()}
+
+    if key_assumption == "upper":
+        matrix_dict_copy = {
+            key: xp.triu(matrix) for key, matrix in matrix_dict_copy.items()
+        }
+    elif key_assumption == "half":
+        matrix_dict_copy = {
+            key: matrix for key, matrix in matrix_dict_copy.items() if key >= (0, 0, 0)
+        }
+
+    test_block = construct_transport_cell(
+        matrix_dict_copy, transport_cell_size, transport_ind, shift, key_assumption
     )
 
-    bs = matrix_dict[(0, 0, 0)].shape[-1]
-    for br in range(transport_cell_size):
-        for bc in range(transport_cell_size):
+    shape = matrix_dict[(0, 0, 0)].shape
+    block_size = matrix_dict[(0, 0, 0)].shape[-1]
+    for r_i in range(transport_cell_size):
+        for r_j in range(transport_cell_size):
             target_ind = list(shift)
-            target_ind[transport_ind] = bc - br
+            target_ind[transport_ind] = r_j - r_i
             target_ind = tuple(target_ind)
 
-            ref_block = matrix_dict.get(target_ind, xp.zeros((bs, bs)))
-
-            if bc > br:
-                ref_block = ref_block + ref_block.conj().T
-                xp.fill_diagonal(ref_block, ref_block.diagonal() / 2)
-            elif bc < br:
-                ref_block = xp.zeros_like(ref_block)
+            ref_block = matrix_dict.get(target_ind, xp.zeros(shape))
 
             assert xp.allclose(
-                test_block[br * bs : (br + 1) * bs, bc * bs : (bc + 1) * bs], ref_block
+                test_block[
+                    ...,
+                    r_i * block_size : (r_i + 1) * block_size,
+                    r_j * block_size : (r_j + 1) * block_size,
+                ],
+                ref_block,
             )
 
 
@@ -115,7 +138,7 @@ def test_expand_tight_binding_matrix(
     block = xp.ones((2, 2))
 
     matrix_dict = {
-        tuple(int(i) for i in ind): block for ind in np.ndindex(hopping_shape)
+        tuple(int(i) for i in ind): xp.triu(block) for ind in np.ndindex(hopping_shape)
     }
 
     for ind in list(matrix_dict.keys()):


### PR DESCRIPTION
This PR will do the following:
- Refactor the `QTBM` contact to slice the system matrix instead of using the store contact blocks. This is beneficial if the contact blocks update, for example, with Poisson, and to later share the contact definition between `SCBA` and `QTBM`.
- Enable the optimization of using transverse periodicity in `SCBA` which will be done through a `SystemReducer`. The helper method will be shared between `SCBA` and `QTBM`.

This PR will be continued after #284 is merged, since otherwise, there will be many conflicts.