### PR TITLE
Profiler deadlock

### DIFF
--- a/src/qttools/profiling/profiler.py
+++ b/src/qttools/profiling/profiler.py
@@ -389,44 +389,45 @@ class Profiler:
         timestamp = time.time()
 
         # NOTE: We maybe need to barrier before starting the timer
+        exception_raised = False
+        try:
+            if xp.__name__ == "cupy":
+                xp.cuda.runtime.deviceSynchronize()
+                if NVTX_AVAILABLE:
+                    xp.cuda.nvtx.RangePush(label)
+            start_time = time.perf_counter()
 
-        if xp.__name__ == "cupy":
-            xp.cuda.runtime.deviceSynchronize()
-            if NVTX_AVAILABLE:
-                xp.cuda.nvtx.RangePush(label)
-        start_time = time.perf_counter()
+            yield
 
-        # NOTE: There is not finally here since this would
-        # potentially lead to deadlocks.
-        # The only issue is that if the profiled code raises an exception,
-        # the depth will not be decreased and the profiling data will be inconsistent.
-        # However, we should always crash when profiled code raises an exception,
-        # so this should not be a problem in practice.
-        yield
+        except Exception:
+            exception_raised = True
+            raise
 
-        if xp.__name__ == "cupy":
-            xp.cuda.runtime.deviceSynchronize()
-            if NVTX_AVAILABLE:
-                xp.cuda.nvtx.RangePop()
+        finally:
+            if xp.__name__ == "cupy":
+                xp.cuda.runtime.deviceSynchronize()
+                if NVTX_AVAILABLE:
+                    xp.cuda.nvtx.RangePop()
 
-        call_time = time.perf_counter() - start_time
+            call_time = time.perf_counter() - start_time
 
-        if comm is not None and QTX_PROFILE_COMM_SYNC:
-            comm.barrier()
-            after_barrier_time = time.perf_counter() - start_time
-        else:
-            after_barrier_time = call_time
+            # Do not barrier when an exception was raised to avoid potential deadlocks.
+            if comm is not None and QTX_PROFILE_COMM_SYNC and not exception_raised:
+                comm.barrier()
+                after_barrier_time = time.perf_counter() - start_time
+            else:
+                after_barrier_time = call_time
 
-        self.eventlog.append(
-            (timestamp, self.depth, label, call_time, after_barrier_time)
-        )
+            self.eventlog.append(
+                (timestamp, self.depth, label, call_time, after_barrier_time)
+            )
 
-        if comm_world.rank == 0:
-            offset = "  " * (self.depth)
-            self.print_file.write(f"{offset}{label} : {call_time:.4f}s")
-            if comm is not None and QTX_PROFILE_COMM_SYNC:
-                self.print_file.write(
-                    f"{offset}{label} all : {after_barrier_time:.4f}s"
-                )
+            if comm_world.rank == 0:
+                offset = "  " * (self.depth)
+                self.print_file.write(f"{offset}{label} : {call_time:.4f}s")
+                if comm is not None and QTX_PROFILE_COMM_SYNC:
+                    self.print_file.write(
+                        f"{offset}{label} all : {after_barrier_time:.4f}s"
+                    )
 
-        self.depth -= 1
+            self.depth -= 1

--- a/src/qttools/profiling/profiler.py
+++ b/src/qttools/profiling/profiler.py
@@ -385,45 +385,42 @@ class Profiler:
         if self.print_file is None:
             raise ValueError("Before profiling, `set_parameters` needs to be called.")
 
-        try:
-            self.depth += 1
-            timestamp = time.time()
+        self.depth += 1
+        timestamp = time.time()
 
-            # NOTE: We maybe need to barrier before starting the timer
+        # NOTE: We maybe need to barrier before starting the timer
 
-            if xp.__name__ == "cupy":
-                xp.cuda.runtime.deviceSynchronize()
-                if NVTX_AVAILABLE:
-                    xp.cuda.nvtx.RangePush(label)
-            start_time = time.perf_counter()
+        if xp.__name__ == "cupy":
+            xp.cuda.runtime.deviceSynchronize()
+            if NVTX_AVAILABLE:
+                xp.cuda.nvtx.RangePush(label)
+        start_time = time.perf_counter()
 
-            yield
+        yield
 
-        finally:
+        if xp.__name__ == "cupy":
+            xp.cuda.runtime.deviceSynchronize()
+            if NVTX_AVAILABLE:
+                xp.cuda.nvtx.RangePop()
 
-            if xp.__name__ == "cupy":
-                xp.cuda.runtime.deviceSynchronize()
-                if NVTX_AVAILABLE:
-                    xp.cuda.nvtx.RangePop()
+        call_time = time.perf_counter() - start_time
 
-            call_time = time.perf_counter() - start_time
+        if comm is not None and QTX_PROFILE_COMM_SYNC:
+            comm.barrier()
+            after_barrier_time = time.perf_counter() - start_time
+        else:
+            after_barrier_time = call_time
 
+        self.eventlog.append(
+            (timestamp, self.depth, label, call_time, after_barrier_time)
+        )
+
+        if comm_world.rank == 0:
+            offset = "  " * (self.depth)
+            self.print_file.write(f"{offset}{label} : {call_time:.4f}s")
             if comm is not None and QTX_PROFILE_COMM_SYNC:
-                comm.barrier()
-                after_barrier_time = time.perf_counter() - start_time
-            else:
-                after_barrier_time = call_time
+                self.print_file.write(
+                    f"{offset}{label} all : {after_barrier_time:.4f}s"
+                )
 
-            self.eventlog.append(
-                (timestamp, self.depth, label, call_time, after_barrier_time)
-            )
-
-            if comm_world.rank == 0:
-                offset = "  " * (self.depth)
-                self.print_file.write(f"{offset}{label} : {call_time:.4f}s")
-                if comm is not None and QTX_PROFILE_COMM_SYNC:
-                    self.print_file.write(
-                        f"{offset}{label} all : {after_barrier_time:.4f}s"
-                    )
-
-            self.depth -= 1
+        self.depth -= 1

--- a/src/qttools/profiling/profiler.py
+++ b/src/qttools/profiling/profiler.py
@@ -396,6 +396,12 @@ class Profiler:
                 xp.cuda.nvtx.RangePush(label)
         start_time = time.perf_counter()
 
+        # NOTE: There is not finally here since this would
+        # potentially lead to deadlocks.
+        # The only issue is that if the profiled code raises an exception,
+        # the depth will not be decreased and the profiling data will be inconsistent.
+        # However, we should always crash when profiled code raises an exception,
+        # so this should not be a problem in practice.
         yield
 
         if xp.__name__ == "cupy":

--- a/src/quatrex/cli/main.py
+++ b/src/quatrex/cli/main.py
@@ -3,9 +3,11 @@
 """Main CLI entrypoint and command dispatch for quatrex."""
 
 from threadpoolctl import threadpool_limits, threadpool_info  # isort: skip
+import os
 import time
+import traceback
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 
 import typer
 from click import BadArgumentUsage
@@ -102,6 +104,42 @@ def _run_negf(config):
             typer.secho(f"Leaving SCBA after: {(toc - tic):.2f} s")
 
 
+def _abort_quatrex(
+    e: Exception,
+) -> NoReturn:
+    """Handles exceptions by printing the error and aborting the MPI program.
+
+    Parameters
+    ----------
+    e : Exception
+        The exception that was raised.
+
+    """
+
+    # Force MPI to abort in the case of an exception
+    # to avoid hanging processes.
+    try:
+        full_traceback = "".join(traceback.format_exception(e))
+
+        error_msg = (
+            f"\n[RANK {comm.rank}] !!! CRITICAL EXCEPTION !!!\n" f"{full_traceback}\n"
+        )
+
+        os.write(2, error_msg.encode("utf-8"))
+    except Exception:
+        fallback_msg = (
+            f"\n[RANK {comm.rank}] Fatal error occurred, traceback formatting failed.\n"
+        )
+        os.write(2, fallback_msg.encode("utf-8"))
+
+    try:
+        comm.Abort(1)
+    except Exception:
+        pass
+
+    raise
+
+
 @quatrex_cli.command()
 def run(
     config: Annotated[
@@ -116,44 +154,50 @@ def run(
     ] = None,
 ):
     """Runs quatrex with the provided configuration."""
-    # No arguments provided, check for the default config file in the
-    # working directory.
-    if config is None:
-        config = Path("./quatrex_config.toml")
-        if not config.exists():
-            raise BadArgumentUsage(
-                "No quatrex configuration file provided and default "
-                "'./quatrex_config.toml' does not exist."
+
+    try:
+        # No arguments provided, check for the default config file in the
+        # working directory.
+        if config is None:
+            config = Path("./quatrex_config.toml")
+            if not config.exists():
+                raise BadArgumentUsage(
+                    "No quatrex configuration file provided and default "
+                    "'./quatrex_config.toml' does not exist."
+                )
+
+        # If a directory is provided, look for the config file inside.
+        if config.is_dir():
+            config = config / "quatrex_config.toml"
+            if not config.exists():
+                raise BadArgumentUsage(
+                    f"No quatrex configuration file found in directory: {config.parent}"
+                )
+
+        from qttools.profiling import Profiler
+        from quatrex.core.config import parse_config, setup_context
+
+        profiler = Profiler()
+
+        config = parse_config(config)
+        setup_context(config)
+
+        secho_header()
+
+        # Dispatch to the appropriate runner based on the formalism.
+        if config.formalism == "wf":
+            _run_wf(config)
+        elif config.formalism == "negf":
+            _run_negf(config)
+        else:
+            raise NotImplementedError(
+                f"Formalism '{config.formalism}' is not implemented."
             )
 
-    # If a directory is provided, look for the config file inside.
-    if config.is_dir():
-        config = config / "quatrex_config.toml"
-        if not config.exists():
-            raise BadArgumentUsage(
-                f"No quatrex configuration file found in directory: {config.parent}"
-            )
-
-    from qttools.profiling import Profiler
-    from quatrex.core.config import parse_config, setup_context
-
-    profiler = Profiler()
-
-    config = parse_config(config)
-    setup_context(config)
-
-    secho_header()
-
-    # Dispatch to the appropriate runner based on the formalism.
-    if config.formalism == "wf":
-        _run_wf(config)
-    elif config.formalism == "negf":
-        _run_negf(config)
-    else:
-        raise NotImplementedError(f"Formalism '{config.formalism}' is not implemented.")
-
-    if config.outputs.save_profiling_results:
-        profiler.dump_stats()
+        if config.outputs.save_profiling_results:
+            profiler.dump_stats()
+    except Exception as e:
+        _abort_quatrex(e)
 
 
 @quatrex_cli.callback(no_args_is_help=True)

--- a/src/quatrex/cli/main.py
+++ b/src/quatrex/cli/main.py
@@ -126,16 +126,16 @@ def _abort_quatrex(
         )
 
         os.write(2, error_msg.encode("utf-8"))
-    except Exception:
-        fallback_msg = (
-            f"\n[RANK {comm.rank}] Fatal error occurred, traceback formatting failed.\n"
-        )
+    except Exception as traceback_exc:
+        fallback_msg = f"\n[RANK {comm.rank}] traceback formatting failed with exception: {traceback_exc}\n"
+
         os.write(2, fallback_msg.encode("utf-8"))
 
     try:
         comm.Abort(1)
-    except Exception:
-        pass
+    except Exception as abort_exc:
+        fallback_abort_msg = f"\n[RANK {comm.rank}] MPI abort failed while handling a fatal exception: {abort_exc}\n"
+        os.write(2, fallback_abort_msg.encode("utf-8"))
 
     raise
 

--- a/src/quatrex/cli/main.py
+++ b/src/quatrex/cli/main.py
@@ -137,7 +137,7 @@ def _abort_quatrex(
         fallback_abort_msg = f"\n[RANK {comm.rank}] MPI abort failed while handling a fatal exception: {abort_exc}\n"
         os.write(2, fallback_abort_msg.encode("utf-8"))
 
-    raise
+    raise e
 
 
 @quatrex_cli.command()
@@ -152,6 +152,13 @@ def run(
             exists=True,
         ),
     ] = None,
+    abort_on_exception: Annotated[
+        bool,
+        typer.Option(
+            "--abort-on-exception/--no-abort-on-exception",
+            help="Force abort the entire MPI environment on an unhandled exception to prevent hanging processes.",
+        ),
+    ] = True,
 ):
     """Runs quatrex with the provided configuration."""
 
@@ -197,7 +204,10 @@ def run(
         if config.outputs.save_profiling_results:
             profiler.dump_stats()
     except Exception as e:
-        _abort_quatrex(e)
+        if abort_on_exception:
+            _abort_quatrex(e)
+        else:
+            raise
 
 
 @quatrex_cli.callback(no_args_is_help=True)

--- a/src/quatrex/cli/main.py
+++ b/src/quatrex/cli/main.py
@@ -3,7 +3,7 @@
 """Main CLI entrypoint and command dispatch for quatrex."""
 
 from threadpoolctl import threadpool_limits, threadpool_info  # isort: skip
-import os
+import sys
 import time
 import traceback
 from pathlib import Path
@@ -104,6 +104,46 @@ def _run_negf(config):
             typer.secho(f"Leaving SCBA after: {(toc - tic):.2f} s")
 
 
+def _resolve_config_path(
+    config: Optional[Path],
+) -> Path:
+    """Resolves the configuration file path based on the provided argument.
+
+    Parameters
+    ----------
+    config : Optional[Path]
+        The user-provided configuration path, which can be:
+        - None: No argument provided, look for default config in working directory.
+        - A file path: Use this as the config file.
+        - A directory path: Look for 'quatrex_config.toml' inside this directory.
+
+    Returns
+    -------
+    Path
+        The resolved path to the configuration file.
+
+    """
+    # No arguments provided, check for the default config file in the
+    # working directory.
+    if config is None:
+        config = Path("./quatrex_config.toml")
+        if not config.exists():
+            raise BadArgumentUsage(
+                "No quatrex configuration file provided and default "
+                "'./quatrex_config.toml' does not exist."
+            )
+
+    # If a directory is provided, look for the config file inside.
+    if config.is_dir():
+        config = config / "quatrex_config.toml"
+        if not config.exists():
+            raise BadArgumentUsage(
+                f"No quatrex configuration file found in directory: {config.parent}"
+            )
+
+    return config.resolve()
+
+
 def _abort_quatrex(
     e: Exception,
 ) -> NoReturn:
@@ -125,17 +165,17 @@ def _abort_quatrex(
             f"\n[RANK {comm.rank}] !!! CRITICAL EXCEPTION !!!\n" f"{full_traceback}\n"
         )
 
-        os.write(2, error_msg.encode("utf-8"))
+        sys.stderr.write(error_msg)
     except Exception as traceback_exc:
         fallback_msg = f"\n[RANK {comm.rank}] traceback formatting failed with exception: {traceback_exc}\n"
 
-        os.write(2, fallback_msg.encode("utf-8"))
+        sys.stderr.write(fallback_msg)
 
     try:
         comm.Abort(1)
     except Exception as abort_exc:
         fallback_abort_msg = f"\n[RANK {comm.rank}] MPI abort failed while handling a fatal exception: {abort_exc}\n"
-        os.write(2, fallback_abort_msg.encode("utf-8"))
+        sys.stderr.write(fallback_abort_msg)
 
     raise e
 
@@ -163,23 +203,7 @@ def run(
     """Runs quatrex with the provided configuration."""
 
     try:
-        # No arguments provided, check for the default config file in the
-        # working directory.
-        if config is None:
-            config = Path("./quatrex_config.toml")
-            if not config.exists():
-                raise BadArgumentUsage(
-                    "No quatrex configuration file provided and default "
-                    "'./quatrex_config.toml' does not exist."
-                )
-
-        # If a directory is provided, look for the config file inside.
-        if config.is_dir():
-            config = config / "quatrex_config.toml"
-            if not config.exists():
-                raise BadArgumentUsage(
-                    f"No quatrex configuration file found in directory: {config.parent}"
-                )
+        config = _resolve_config_path(config)
 
         from qttools.profiling import Profiler
         from quatrex.core.config import parse_config, setup_context
@@ -206,8 +230,7 @@ def run(
     except Exception as e:
         if abort_on_exception:
             _abort_quatrex(e)
-        else:
-            raise
+        raise
 
 
 @quatrex_cli.callback(no_args_is_help=True)

--- a/tests/quatrex/reference/test_reference.py
+++ b/tests/quatrex/reference/test_reference.py
@@ -67,7 +67,7 @@ def test_single_rank(
     adjust_config_paths(quatrex_config_path, tmp_config_path)
 
     # Run the example using the CLI.
-    cli_run(tmp_config_path)
+    cli_run(tmp_config_path, abort_on_exception=False)
 
     output_dir = tmp_path / "outputs"
     reference_output_dir = example_path / "reference-outputs"
@@ -96,7 +96,7 @@ def test_distributed(
     comm.barrier()  # Ensure all ranks wait until the config is set up.
 
     # Run the example using the CLI.
-    cli_run(tmp_config_path)
+    cli_run(tmp_config_path, abort_on_exception=False)
 
     comm.barrier()  # Ensure all ranks wait until the run is complete.
 


### PR DESCRIPTION
This PR addresses #275.
It is fixed by removing the `finally` inside the profiler.
Further, logic is included in the CLI to abort the program in case of failure.
It was observed that the program hangs on Alps when throwing an exception.