### PR TITLE
Scba batching

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,11 @@ on:
 jobs:
   test-cov:
     runs-on: ubuntu-latest
+    env:
+      OMP_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      NUMBA_NUM_THREADS: 1
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      
+
       - name: Get Git LFS Files
         run: git lfs pull
 
@@ -47,15 +47,15 @@ jobs:
       - name: Run NUMBA Tests (QTTools Kernels)
         if: success() || failure()
         run: |
-          coverage run --source=src --parallel-mode -m pytest -vv tests/qttools/kernels
+          coverage run --source=src --parallel-mode -m pytest -n auto -vv tests/qttools/kernels
 
       - name: Run QTTools Tests
         if: success() || failure()
         run: |
-          NUMBA_DISABLE_JIT=1 coverage run --source=src --parallel-mode -m pytest -vv tests/qttools
-      
+          NUMBA_DISABLE_JIT=1 coverage run --source=src --parallel-mode -m pytest -n auto -vv tests/qttools
+
       - name: Run QuaTrEx Tests and Determine Coverage
         if: success() || failure()
         run: |
-          coverage run --source=src --parallel-mode -m pytest -vv tests/quatrex
+          coverage run --source=src --parallel-mode -m pytest -n auto -vv tests/quatrex
           coverage combine .; coverage report; coverage xml

--- a/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/quatrex_config.toml
@@ -49,6 +49,7 @@ energy_window_min = -10
 energy_window_max = 0
 energy_window_num = 100
 
+max_batch_size = 15
 solver.algorithm = "rgf"
 solver.max_batch_size = 1000
 solver.compute_current = true # Compute Meir-Wingreen current.
@@ -78,6 +79,7 @@ epsilon_r = 4
 
 num_connected_blocks = 1 # Can be 1, 2, 3, or "auto"
 
+max_batch_size = 15
 solver.algorithm = "rgf"
 solver.max_batch_size = 1000
 

--- a/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
+++ b/examples/w90/mos2/gw-kpoints-symmetric/quatrex_config.toml
@@ -52,6 +52,7 @@ energy_window_num = 100
 
 eta = 1e-5
 
+max_batch_size = 15
 solver.algorithm = "rgf"
 solver.max_batch_size = 1000
 solver.compute_current = true # Compute Meir-Wingreen current.
@@ -84,6 +85,7 @@ epsilon_r = 100.0
 
 num_connected_blocks = 2 # Can be 1, 2, 3, or "auto"
 
+max_batch_size = 15
 solver.algorithm = "rgf"
 solver.max_batch_size = 1000
 

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -850,8 +850,15 @@ class DSDBSparse(ABC):
             )
             stack_size = 1
 
-        if stack_size is None or stack_size == 0:
+        if stack_size is None:
             stack_size = int(max(self.stack_section_sizes))
+        # NOTE: Edge case for when the stack size is 0
+        if stack_size == 0:
+            warnings.warn(
+                "Stack size of 0 is not valid."
+                "Allocating data with a unit stack section size."
+            )
+            stack_size = 1
 
         if self._data is None:
             self._data = xp.empty(

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -817,7 +817,18 @@ class DSDBSparse(ABC):
         free_mempool()
 
     def allocate_data(self, stack_size: int | None = None) -> None:
-        """Allocates the local data."""
+        """Allocates the local data.
+
+        This should not be called with a non-None stack size
+        if the data will be dtransposed.
+
+        Parameters
+        ----------
+        stack_size : int, optional
+            The size of the stack dimension to allocate. If None, the full
+            stack size is used. Default is None.
+
+        """
         free_mempool()
 
         # NOTE: Dangerous

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the qttools package.
 
 import itertools
+import numbers
+import warnings
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -814,13 +816,36 @@ class DSDBSparse(ABC):
         self._data = None
         free_mempool()
 
-    def allocate_data(self) -> None:
+    def allocate_data(self, stack_size: int | None = None) -> None:
         """Allocates the local data."""
         free_mempool()
+
+        # NOTE: Dangerous
+        # but we assume there is no padding
+        # and no all-to-all will be performed
+        # TODO: We should have a non distributed
+        # version without padding and cheaper initialization
+        if stack_size is not None:
+            self.data_slice_stack = (
+                slice(None, int(stack_size)),
+                ...,
+                slice(None, int(self.nnz_section_offsets[-1])),
+            )
+
+        if stack_size == 0:
+            warnings.warn(
+                "Stack size of 0 is not valid."
+                "Allocating data with a unit stack section size."
+            )
+            stack_size = 1
+
+        if stack_size is None or stack_size == 0:
+            stack_size = int(max(self.stack_section_sizes))
+
         if self._data is None:
             self._data = xp.empty(
                 (
-                    int(max(self.stack_section_sizes)),
+                    stack_size,
                     *self.global_stack_shape[1:],
                     self.total_nnz_size,
                 ),
@@ -903,6 +928,10 @@ def _replace_ellipsis(stack_index: tuple, ndim: int) -> tuple:
         The stack index with the ellipsis replaced.
 
     """
+
+    if not isinstance(stack_index, tuple):
+        stack_index = (stack_index,)
+
     is_ellipsis = [i for i, ind in enumerate(stack_index) if ind is Ellipsis]
     if is_ellipsis:
         if len(is_ellipsis) > 1:
@@ -920,6 +949,76 @@ def _replace_ellipsis(stack_index: tuple, ndim: int) -> tuple:
     return stack_index
 
 
+def _compose_single(lhs: int | slice, rhs: int | slice, length: int) -> int | slice:
+    """Composes two unidimensional indices or slices.
+
+    Example:
+        length = 30  # dimension of length 30
+        lhs = slice(2, 27, 2)  # selects indices [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26]
+        rhs = slice(1, 11, 3)  # selects indices [1, 4, 7, 10] from the previous selection,
+                               # i.e., [4, 10, 16, 22] from the original dimension
+        result = _compose_single(lhs, rhs, 30)
+        # result is slice(4, 22, 6), which selects indices [4, 10, 16, 22] from the original dimension.
+
+    Parameters
+    ----------
+    lhs : int | slice
+        The first index or slice.
+    rhs : int | slice
+        The second index or slice.
+    length : int
+        The length of the dimension being indexed.
+
+    Returns
+    -------
+    int | slice
+        The composed index or slice.
+    """
+    out = range(length)[lhs][rhs]
+    return out if isinstance(out, int) else slice(out.start, out.stop, out.step)
+
+
+def _compose(
+    shape: tuple[int, ...],
+    first: tuple[int, ...] | int | slice,
+    second: tuple[int, ...] | int | slice,
+) -> tuple[int | slice, ...]:
+    """Composes two multidimensional indices or slices.
+
+    Parameters
+    ----------
+    shape : tuple
+        The shape of the array being indexed.
+    first : tuple | int | slice
+        The first index or slice.
+    second : tuple | int | slice
+        The second index or slice.
+
+    Returns
+    -------
+    tuple
+        The composed index or slice.
+    """
+
+    def ensure_tuple(ndslice):
+        return ndslice if isinstance(ndslice, tuple) else (ndslice,)
+
+    # Ensure both are tuples for easier processing
+    first = ensure_tuple(first)
+    second = ensure_tuple(second)
+
+    # Initialize output with first index/slice and fill the rest with full slices
+    out = list(first) + [slice(None)] * (len(shape) - len(first))
+
+    # We only need to compose the slice dimensions (not the indices).
+    # NOTE: It is implied that for any dimensions excluded here, the corresponding index in `second` is 0.
+    remaining_dims = [i for i, s in enumerate(out) if isinstance(s, slice)]
+
+    for i, rhs in zip(remaining_dims, second):
+        out[i] = _compose_single(out[i], rhs, length=shape[i])
+    return tuple(out)
+
+
 class _DStackIndexer:
     """A utility class to locate substacks in the distributed stack.
 
@@ -930,18 +1029,35 @@ class _DStackIndexer:
 
     """
 
-    def __init__(self, dsdbsparse: DSDBSparse) -> None:
+    def __init__(self, dsdbsparse: "DSDBSparse | _DStackView") -> None:
         """Initializes the stack indexer."""
-        self._dsdbsparse = dsdbsparse
+        if isinstance(dsdbsparse, _DStackView):
+            self._dsdbsparse = dsdbsparse._dsdbsparse
+            self._base_index = dsdbsparse._stack_index
+        else:
+            self._dsdbsparse = dsdbsparse
+            self._base_index = None
 
     def __getitem__(self, index: tuple) -> "_DStackView":
         """Gets a substack view."""
-        return _DStackView(self._dsdbsparse, index)
+        if self._base_index is not None:
+            index = _replace_ellipsis(index, self._dsdbsparse.data.ndim)
+            composition = _compose(
+                self._dsdbsparse.stack_shape, self._base_index, index
+            )
+        else:
+            composition = index
+        return _DStackView(self._dsdbsparse, composition)
 
     def __setitem__(
         self, stack_index: tuple, other: "DSDBSparse | sparse.spmatrix"
     ) -> None:
         """Sets a substack."""
+
+        if self._base_index is not None:
+            raise NotImplementedError(
+                "Setting a substack of a substack is not supported."
+            )
 
         stack_index = _replace_ellipsis(stack_index, self._dsdbsparse.data.ndim)
 
@@ -972,8 +1088,6 @@ class _DStackView:
         """Initializes the stack indexer."""
         self._dsdbsparse = dsdbsparse
         self.symmetry = dsdbsparse.symmetry
-        if not isinstance(stack_index, tuple):
-            stack_index = (stack_index,)
         stack_index = _replace_ellipsis(stack_index, self._dsdbsparse.data.ndim)
         self._stack_index = stack_index
         self._block_indexer = _DSDBlockIndexer(
@@ -982,6 +1096,21 @@ class _DStackView:
         self._sparse_block_indexer = _DSDBlockIndexer(
             self._dsdbsparse, self._stack_index, return_dense=False, cache_stack=True
         )
+
+        shape = self._dsdbsparse.shape
+        stack_size = []
+        for i, s in enumerate(stack_index):
+            if isinstance(s, slice):
+                start = s.start if s.start is not None else 0
+                stop = s.stop if s.stop is not None else shape[i]
+                stack_size.append(stop - start)
+            elif isinstance(s, (int, numbers.Integral)):
+                stack_size.append(1)
+            else:
+                raise IndexError(
+                    f"Expected slice or int in stack index but got {type(s)} ({s=})."
+                )
+        self.shape = tuple(stack_size) + shape[len(stack_index) :]
 
     def __getitem__(self, index: tuple[ArrayLike, ArrayLike]) -> NDArray:
         """Gets the requested data from the substack."""
@@ -992,6 +1121,11 @@ class _DStackView:
         """Sets the requested data in the substack."""
         rows, cols = self._dsdbsparse._normalize_index(index)
         self._dsdbsparse._set_items(self._stack_index, rows, cols, values)
+
+    @property
+    def stack(self) -> "_DStackIndexer":
+        """Returns the stack indexer on the substack."""
+        return _DStackIndexer(self)
 
     def __iadd__(self, other: "DSDBSparse | sparse.spmatrix") -> "DSDBSparse":
         """In-place addition of sparse matrix."""

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -1134,6 +1134,11 @@ class _DStackView:
         self._dsdbsparse._set_items(self._stack_index, rows, cols, values)
 
     @property
+    def distribution_state(self):
+        """Returns the distribution state of the substack."""
+        return self._dsdbsparse.distribution_state
+
+    @property
     def dtype(self):
         """Returns the dtype."""
         return self._dsdbsparse.dtype

--- a/src/qttools/datastructures/dsdbsparse.py
+++ b/src/qttools/datastructures/dsdbsparse.py
@@ -1123,9 +1123,34 @@ class _DStackView:
         self._dsdbsparse._set_items(self._stack_index, rows, cols, values)
 
     @property
+    def dtype(self):
+        """Returns the dtype."""
+        return self._dsdbsparse.dtype
+
+    @property
     def stack(self) -> "_DStackIndexer":
         """Returns the stack indexer on the substack."""
         return _DStackIndexer(self)
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of global (?) blocks."""
+        return self._dsdbsparse.num_blocks
+
+    @property
+    def block_sizes(self) -> list[int]:
+        """Returns the global block sizes."""
+        return self._dsdbsparse.block_sizes
+
+    @property
+    def data(self) -> NDArray:
+        """Returns the local slice of the data, masking the padding."""
+        return self._dsdbsparse.data[self._stack_index]
+
+    @data.setter
+    def data(self, value: NDArray) -> None:
+        """Sets the local slice of the data."""
+        self._dsdbsparse.data[self._stack_index] = value
 
     def __iadd__(self, other: "DSDBSparse | sparse.spmatrix") -> "DSDBSparse":
         """In-place addition of sparse matrix."""

--- a/src/qttools/datastructures/routines.py
+++ b/src/qttools/datastructures/routines.py
@@ -2,7 +2,7 @@
 
 from qttools import xp
 from qttools.comm import comm
-from qttools.datastructures.dsdbsparse import DSDBSparse
+from qttools.datastructures.dsdbsparse import DSDBSparse, _DStackView
 
 
 def _bd_sandwich(
@@ -468,9 +468,9 @@ def bd_matmul(
 
 
 def bd_sandwich(
-    a: DSDBSparse,
-    b: DSDBSparse,
-    out: DSDBSparse,
+    a: DSDBSparse | _DStackView,
+    b: DSDBSparse | _DStackView,
+    out: DSDBSparse | _DStackView,
     in_num_diag: int = 3,
     out_num_diag: int = 7,
     start_block: int = 0,

--- a/src/qttools/greens_function_solver/_serinv.py
+++ b/src/qttools/greens_function_solver/_serinv.py
@@ -255,9 +255,6 @@ class ReducedSystem:
             )
         )
 
-        if comm.rank == 0:
-            print("Gathering reduced system.", flush=True)
-
         synchronize_device()
         comm.block.all_gather(
             xr_diag_blocks[2 * comm.block.rank : 2 * (comm.block.rank + 1)],

--- a/src/qttools/greens_function_solver/rgf.py
+++ b/src/qttools/greens_function_solver/rgf.py
@@ -175,10 +175,14 @@ class RGF(GFSolver):
             # Allocate a buffer for the current. This includes current
             # between each layer and from/to the leads (in total
             # num_blocks + 1).
-            current = xp.zeros((*a.shape[:-2], a.num_blocks + 1), dtype=a.dtype)
+            current = xp.zeros(
+                (*sigma_lesser.shape[:-2], a.num_blocks + 1), dtype=a.dtype
+            )
 
         # Get list of batches to perform
-        batches_sizes, batches_slices = get_batches(a.shape[0], self.max_batch_size)
+        batches_sizes, batches_slices = get_batches(
+            sigma_lesser.shape[0], self.max_batch_size
+        )
 
         # If out is not none, xr will be the third element of the tuple.
         if out is not None:

--- a/src/qttools/greens_function_solver/rgf.py
+++ b/src/qttools/greens_function_solver/rgf.py
@@ -164,19 +164,20 @@ class RGF(GFSolver):
 
         """
         # Initialize empty lists for the dense diagonal blocks.
-        xr_diag_blocks: list[NDArray | None] = [None] * a.num_blocks
-        xl_diag_blocks: list[NDArray | None] = [None] * a.num_blocks
-        xg_diag_blocks: list[NDArray | None] = [None] * a.num_blocks
+        xr_diag_blocks: list[NDArray | None] = [None] * sigma_lesser.num_blocks
+        xl_diag_blocks: list[NDArray | None] = [None] * sigma_lesser.num_blocks
+        xg_diag_blocks: list[NDArray | None] = [None] * sigma_lesser.num_blocks
 
         if obc_blocks is None:
-            obc_blocks = OBCBlocks(num_blocks=a.num_blocks)
+            obc_blocks = OBCBlocks(num_blocks=sigma_lesser.num_blocks)
 
         if return_current:
             # Allocate a buffer for the current. This includes current
             # between each layer and from/to the leads (in total
             # num_blocks + 1).
             current = xp.zeros(
-                (*sigma_lesser.shape[:-2], a.num_blocks + 1), dtype=a.dtype
+                (*sigma_lesser.shape[:-2], sigma_lesser.num_blocks + 1),
+                dtype=sigma_lesser.dtype,
             )
 
         # Get list of batches to perform

--- a/src/qttools/greens_function_solver/rgf_dist.py
+++ b/src/qttools/greens_function_solver/rgf_dist.py
@@ -177,27 +177,42 @@ class RGFDist(GFSolver):
             # Initialize temporary buffers.
             reduced_system = _serinv.ReducedSystem(selected_solve=True)
 
-            xr_diag_blocks: list[NDArray | None] = [None] * a.num_local_blocks
-            xr_buffer_lower: list[NDArray | None] = [None] * a.num_local_blocks
-            xr_buffer_upper: list[NDArray | None] = [None] * a.num_local_blocks
+            xr_diag_blocks: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
+            xr_buffer_lower: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
+            xr_buffer_upper: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
 
-            xl_diag_blocks: list[NDArray | None] = [None] * a.num_local_blocks
+            xl_diag_blocks: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
             xl_buffer_lower = None
-            xl_buffer_upper: list[NDArray | None] = [None] * a.num_local_blocks
+            xl_buffer_upper: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
 
-            xg_diag_blocks: list[NDArray | None] = [None] * a.num_local_blocks
+            xg_diag_blocks: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
             xg_buffer_lower = None
-            xg_buffer_upper: list[NDArray | None] = [None] * a.num_local_blocks
+            xg_buffer_upper: list[NDArray | None] = [
+                None
+            ] * sigma_lesser.num_local_blocks
 
             if obc_blocks is None:
-                obc_blocks = OBCBlocks(num_blocks=a.num_local_blocks)
+                obc_blocks = OBCBlocks(num_blocks=sigma_lesser.num_local_blocks)
 
             if return_current:
                 # Allocate a buffer for the current. This includes current
                 # between each layer and from/to the leads (in total
                 # num_blocks + 1).
                 current = xp.zeros(
-                    (*sigma_lesser.shape[:-2], a.num_blocks + 1), dtype=a.dtype
+                    (*sigma_lesser.shape[:-2], sigma_lesser.num_blocks + 1),
+                    dtype=sigma_lesser.dtype,
                 )
                 # TODO: Only boundary currents are currently supported.
                 # Invalidate the remaining layers by setting them to

--- a/src/qttools/greens_function_solver/rgf_dist.py
+++ b/src/qttools/greens_function_solver/rgf_dist.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from qttools import NDArray, xp
 from qttools.comm import comm
-from qttools.datastructures.dsdbsparse import DSDBSparse
+from qttools.datastructures.dsdbsparse import DSDBSparse, _DStackView
 from qttools.greens_function_solver import _serinv
 from qttools.greens_function_solver.solver import GFSolver, OBCBlocks
 from qttools.profiling import Profiler
@@ -133,10 +133,10 @@ class RGFDist(GFSolver):
 
     def selected_solve(
         self,
-        a: DSDBSparse,
-        sigma_lesser: DSDBSparse,
-        sigma_greater: DSDBSparse,
-        out: tuple[DSDBSparse, ...],
+        a: DSDBSparse | _DStackView,
+        sigma_lesser: DSDBSparse | _DStackView,
+        sigma_greater: DSDBSparse | _DStackView,
+        out: tuple[DSDBSparse, ...] | tuple[_DStackView, ...],
         obc_blocks: OBCBlocks | None = None,
         return_retarded: bool = False,
         return_current: bool = False,
@@ -196,7 +196,9 @@ class RGFDist(GFSolver):
                 # Allocate a buffer for the current. This includes current
                 # between each layer and from/to the leads (in total
                 # num_blocks + 1).
-                current = xp.zeros((*a.shape[:-2], a.num_blocks + 1), dtype=a.dtype)
+                current = xp.zeros(
+                    (*sigma_lesser.shape[:-2], a.num_blocks + 1), dtype=a.dtype
+                )
                 # TODO: Only boundary currents are currently supported.
                 # Invalidate the remaining layers by setting them to
                 # xp.nan.
@@ -208,7 +210,9 @@ class RGFDist(GFSolver):
                     raise ValueError("Invalid number of output matrices.")
                 xr_out = xr_out[0]
 
-            batch_sizes, batch_offsets = get_batches(a.shape[0], self.max_batch_size)
+            batch_sizes, batch_offsets = get_batches(
+                sigma_lesser.shape[0], self.max_batch_size
+            )
 
             for i in range(len(batch_sizes)):
                 stack_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))

--- a/src/quatrex/core/config.py
+++ b/src/quatrex/core/config.py
@@ -543,12 +543,15 @@ class ElectronConfig(BaseModel):
     filtering_iteration_limit: PositiveInt = 1
 
     max_batch_size: PositiveInt | None = None
-    """The maximum number of energies per batch for the electronic subsystem.
-    
-    This controls the batching of the boundary condition and Green's function
-    solvers in the electronic subsystem. If not set, all energies are computed
-    at once.
-    
+    """The maximum number of energies to batch together in the solution
+    of the electronic subsystem.
+
+    This controls how many energies are treated together when computing boundary
+    conditions and electron Green's functions. If not set, all energies are
+    computed at once.
+
+    This can help mitigate memory bottlenecks.
+
     """
 
     @model_validator(mode="after")
@@ -714,12 +717,14 @@ class CoulombScreeningConfig(BaseModel):
         return self
 
     max_batch_size: PositiveInt | None = None
-    """The maximum number of energies per batch for the Coulomb screening
-    subsystem.
+    """The maximum number of energies to batch together in the solution
+    of the screened Coulomb interaction.
 
-    This controls the batching of the boundary condition and screend coulomb
-    interaction solver in the Coulomb screening subsystem. If not set, all
-    energies are computed at once.
+    This controls how many energies are treated together when computing boundary
+    conditions and screened Coulomb interactions. If not set, all energies are
+    computed at once.
+
+    This can help mitigate memory bottlenecks.
 
     """
 
@@ -864,8 +869,8 @@ class DeviceConfig(BaseModel):
 
     If set to `None`, all neighbor cells are considered. A
     `neighbor_cell_cutoff` of zero means that only the unit cell itself
-    is considered. 
-    
+    is considered.
+
     Along the transport direction, at least one neighboring cell must be
     included if `construct_from_unit_cell` is `True`. If
     `construct_from_unit_cell` is `False`, no neighboring cells should be

--- a/src/quatrex/core/config.py
+++ b/src/quatrex/core/config.py
@@ -542,6 +542,15 @@ class ElectronConfig(BaseModel):
 
     filtering_iteration_limit: PositiveInt = 1
 
+    max_batch_size: PositiveInt | None = None
+    """The maximum number of energies per batch for the electronic subsystem.
+    
+    This controls the batching of the boundary condition and Green's function
+    solvers in the electronic subsystem. If not set, all energies are computed
+    at once.
+    
+    """
+
     @model_validator(mode="after")
     def set_left_right_fermi_levels(self) -> Self:
         """Sets the left and right Fermi levels if not already set."""
@@ -703,6 +712,16 @@ class CoulombScreeningConfig(BaseModel):
             )
 
         return self
+
+    max_batch_size: PositiveInt | None = None
+    """The maximum number of energies per batch for the Coulomb screening
+    subsystem.
+
+    This controls the batching of the boundary condition and screend coulomb
+    interaction solver in the Coulomb screening subsystem. If not set, all
+    energies are computed at once.
+
+    """
 
 
 class PhotonConfig(BaseModel):

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -14,6 +14,7 @@ from qttools.toeplitz.toeplitz import (
     homogenize,
 )
 from qttools.utils.mpi_utils import get_section_sizes
+from qttools.utils.solvers_utils import get_batches
 from qttools.utils.sparse_utils import product_sparsity_pattern_dsdbsparse
 from quatrex.core.config import QuatrexConfig
 from quatrex.core.statistics import bose_einstein
@@ -190,6 +191,8 @@ class CoulombScreeningSolver(SubsystemSolver):
         self.filtering_iteration_limit = (
             config.coulomb_screening.filtering_iteration_limit
         )
+
+        self.max_batch_size = config.coulomb_screening.max_batch_size
 
     def _set_block_sizes(self, block_sizes: NDArray) -> None:
         """Sets the block sizes of all matrices.
@@ -373,7 +376,13 @@ class CoulombScreeningSolver(SubsystemSolver):
         )
 
     @profiler.profile(label="CoulombScreeningSolver: OBC", level="default", comm=comm)
-    def _compute_obc(self, p_lesser, p_greater, p_retarded) -> None:
+    def _compute_obc(
+        self,
+        p_lesser: DSDBSparse,
+        p_greater: DSDBSparse,
+        p_retarded: DSDBSparse,
+        stack_slice: slice,
+    ) -> None:
         """Computes open boundary conditions (OBC).
 
         Both the OBC for retarded and lesser/greater components are
@@ -398,11 +407,13 @@ class CoulombScreeningSolver(SubsystemSolver):
             The greater polarization.
         p_retarded : DSDBSparse
             The retarded polarization.
+        stack_slice : slice
+            The slice of the energy stack corresponding to the current batch.
 
         """
         if comm.block.rank == 0:
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="left",
+                contact="left-" + str(stack_slice),
                 p_lesser=p_lesser,
                 p_greater=p_greater,
                 p_retarded=p_retarded,
@@ -418,7 +429,7 @@ class CoulombScreeningSolver(SubsystemSolver):
             n = p_retarded.num_local_blocks - 1
             m = n - 1
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="right",
+                contact="right-" + str(stack_slice),
                 p_lesser=p_lesser,
                 p_greater=p_greater,
                 p_retarded=p_retarded,
@@ -732,99 +743,134 @@ class CoulombScreeningSolver(SubsystemSolver):
             retarded).
 
         """
-        with profiler.profile_range(
-            label="CoulombScreeningSolver: Set block sizes", level="default", comm=comm
-        ):
-            self.system_matrix.allocate_data()
-            self.l_lesser.allocate_data()
-            self.l_greater.allocate_data()
-            # Change the block sizes to match the Coulomb matrix.
-            self._set_block_sizes(self.small_block_sizes)
 
-        self.p_retarded.allocate_data()
-        self._assemble_retarded_polarization(
-            p_lesser,
-            p_greater,
-            p_retarded_hermitian,
-        )
+        if self.max_batch_size is None:
+            max_batch_size = p_lesser.shape[0]
+        else:
+            max_batch_size = self.max_batch_size
+        batch_sizes, batch_offsets = get_batches(p_lesser.shape[0], max_batch_size)
 
-        # Assemble the system matrix (Includes matrix multiplication).
-        self._assemble_system_matrix()
+        for i in range(len(batch_sizes)):
 
-        # Apply the OBC algorithm.
-        self._compute_obc(
-            p_lesser,
-            p_greater,
-            self.p_retarded,
-        )
+            stack_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
+            off_slice = slice(0, int(batch_offsets[i + 1] - batch_offsets[i]))
 
-        self.p_retarded.free_data()
+            # Free data when the batch size changes
+            if i > 0 and batch_sizes[i] != batch_sizes[i - 1]:
+                self.system_matrix.free_data()
+                self.l_lesser.free_data()
+                self.l_greater.free_data()
 
-        with profiler.profile_range(
-            label="CoulombScreeningSolver: Sandwich", level="default", comm=comm
-        ):
-            local_blocks, _ = get_section_sizes(
-                len(self.coulomb_matrix.block_sizes), comm.block.size
-            )
-            start_block = sum(local_blocks[: comm.block.rank])
-            end_block = start_block + local_blocks[comm.block.rank]
-            bd_sandwich(
-                a=self.coulomb_matrix,
-                b=p_lesser,
-                out=self.l_lesser,
-                start_block=start_block,
-                end_block=end_block,
-            )
-            self._apply_spillover_sandwich(p_lesser, self.l_lesser)
-
-            bd_sandwich(
-                a=self.coulomb_matrix,
-                b=p_greater,
-                out=self.l_greater,
-                start_block=start_block,
-                end_block=end_block,
-            )
-            self._apply_spillover_sandwich(p_greater, self.l_greater)
-
-        if self.flatband:
             with profiler.profile_range(
-                label="CoulombScreeningSolver: Homogenize", level="default", comm=comm
+                label="CoulombScreeningSolver: Set block sizes",
+                level="default",
+                comm=comm,
             ):
-                homogenize(self.system_matrix)
-                homogenize(self.l_lesser)
-                homogenize(self.l_greater)
+                self.p_retarded.allocate_data(stack_size=batch_sizes[i])
+                self.system_matrix.allocate_data(stack_size=batch_sizes[i])
+                self.l_lesser.allocate_data(stack_size=batch_sizes[i])
+                self.l_greater.allocate_data(stack_size=batch_sizes[i])
 
-        with profiler.profile_range(
-            label="CoulombScreeningSolver: Set block sizes back",
-            level="default",
-            comm=comm,
-        ):
-            # Go back to normal block sizes.
-            self._set_block_sizes(self.block_sizes)
+                p_lesser_tmp = p_lesser.stack[stack_slice]
+                p_greater_tmp = p_greater.stack[stack_slice]
+                p_retarded_hermitian_tmp = p_retarded_hermitian.stack[stack_slice]
+                l_lesser_tmp = self.l_lesser.stack[off_slice]
+                l_greater_tmp = self.l_greater.stack[off_slice]
 
-        with profiler.profile_range(
-            label="CoulombScreeningSolver: Solve", level="default", comm=comm
-        ):
-            # Solve the system
-            if comm.block.size > 1:
-                self.solver_dist.selected_solve(
-                    a=self.system_matrix,
-                    sigma_lesser=self.l_lesser,
-                    sigma_greater=self.l_greater,
-                    obc_blocks=self.obc_blocks,
-                    out=out,
-                    return_retarded=False,
+                # Change the block sizes to match the Coulomb matrix.
+                self._set_block_sizes(self.small_block_sizes)
+
+            self._assemble_retarded_polarization(
+                p_lesser_tmp,
+                p_greater_tmp,
+                p_retarded_hermitian_tmp,
+            )
+
+            # Assemble the system matrix (Includes matrix multiplication).
+            self._assemble_system_matrix()
+
+            # Apply the OBC algorithm.
+            self._compute_obc(
+                p_lesser_tmp,
+                p_greater_tmp,
+                self.p_retarded,
+                stack_slice,
+            )
+            self.p_retarded.free_data()
+
+            with profiler.profile_range(
+                label="CoulombScreeningSolver: Sandwich", level="default", comm=comm
+            ):
+                local_blocks, _ = get_section_sizes(
+                    len(self.coulomb_matrix.block_sizes), comm.block.size
+                )
+                start_block = sum(local_blocks[: comm.block.rank])
+                end_block = start_block + local_blocks[comm.block.rank]
+                bd_sandwich(
+                    self.coulomb_matrix,
+                    p_lesser_tmp,
+                    out=l_lesser_tmp,
+                    start_block=start_block,
+                    end_block=end_block,
+                )
+                self._apply_spillover_sandwich(p_lesser_tmp, l_lesser_tmp)
+
+                bd_sandwich(
+                    self.coulomb_matrix,
+                    p_greater_tmp,
+                    out=l_greater_tmp,
+                    start_block=start_block,
+                    end_block=end_block,
+                )
+                self._apply_spillover_sandwich(p_greater_tmp, l_greater_tmp)
+
+            if self.flatband:
+                with profiler.profile_range(
+                    label="CoulombScreeningSolver: Homogenize",
+                    level="default",
+                    comm=comm,
+                ):
+                    homogenize(self.system_matrix)
+                    homogenize(l_lesser_tmp)
+                    homogenize(l_greater_tmp)
+
+            with profiler.profile_range(
+                label="CoulombScreeningSolver: Set block sizes back",
+                level="default",
+                comm=comm,
+            ):
+                # Go back to normal block sizes.
+                self._set_block_sizes(self.block_sizes)
+
+            with profiler.profile_range(
+                label="CoulombScreeningSolver: Solve", level="default", comm=comm
+            ):
+                out_l, out_g = out
+                out_slice = (
+                    out_l.stack[stack_slice],
+                    out_g.stack[stack_slice],
                 )
 
-            else:
-                self.solver.selected_solve(
-                    a=self.system_matrix,
-                    sigma_lesser=self.l_lesser,
-                    sigma_greater=self.l_greater,
-                    obc_blocks=self.obc_blocks,
-                    out=out,
-                    return_retarded=False,
-                )
+                # Solve the system
+                if comm.block.size > 1:
+                    self.solver_dist.selected_solve(
+                        a=self.system_matrix,
+                        sigma_lesser=l_lesser_tmp,
+                        sigma_greater=l_greater_tmp,
+                        obc_blocks=self.obc_blocks,
+                        out=out_slice,
+                        return_retarded=False,
+                    )
+
+                else:
+                    self.solver.selected_solve(
+                        a=self.system_matrix,
+                        sigma_lesser=l_lesser_tmp,
+                        sigma_greater=l_greater_tmp,
+                        obc_blocks=self.obc_blocks,
+                        out=out_slice,
+                        return_retarded=False,
+                    )
 
         with profiler.profile_range(
             label="CoulombScreeningSolver: Filter", level="default", comm=comm

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -381,7 +381,7 @@ class CoulombScreeningSolver(SubsystemSolver):
         p_lesser: DSDBSparse,
         p_greater: DSDBSparse,
         p_retarded: DSDBSparse,
-        stack_slice: slice,
+        batch_slice: slice,
     ) -> None:
         """Computes open boundary conditions (OBC).
 
@@ -407,13 +407,13 @@ class CoulombScreeningSolver(SubsystemSolver):
             The greater polarization.
         p_retarded : DSDBSparse
             The retarded polarization.
-        stack_slice : slice
+        batch_slice : slice
             The slice of the energy stack corresponding to the current batch.
 
         """
         if comm.block.rank == 0:
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="left-" + str(stack_slice),
+                contact="left-" + str(batch_slice),
                 p_lesser=p_lesser,
                 p_greater=p_greater,
                 p_retarded=p_retarded,
@@ -429,7 +429,7 @@ class CoulombScreeningSolver(SubsystemSolver):
             n = p_retarded.num_local_blocks - 1
             m = n - 1
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="right-" + str(stack_slice),
+                contact="right-" + str(batch_slice),
                 p_lesser=p_lesser,
                 p_greater=p_greater,
                 p_retarded=p_retarded,
@@ -752,7 +752,7 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         for i in range(len(batch_sizes)):
 
-            stack_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
+            batch_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
             off_slice = slice(0, int(batch_offsets[i + 1] - batch_offsets[i]))
 
             # Free data when the batch size changes
@@ -771,19 +771,19 @@ class CoulombScreeningSolver(SubsystemSolver):
                 self.l_lesser.allocate_data(stack_size=batch_sizes[i])
                 self.l_greater.allocate_data(stack_size=batch_sizes[i])
 
-                p_lesser_tmp = p_lesser.stack[stack_slice]
-                p_greater_tmp = p_greater.stack[stack_slice]
-                p_retarded_hermitian_tmp = p_retarded_hermitian.stack[stack_slice]
-                l_lesser_tmp = self.l_lesser.stack[off_slice]
-                l_greater_tmp = self.l_greater.stack[off_slice]
+                p_lesser_batch = p_lesser.stack[batch_slice]
+                p_greater_batch = p_greater.stack[batch_slice]
+                p_retarded_hermitian_batch = p_retarded_hermitian.stack[batch_slice]
+                l_lesser_batch = self.l_lesser.stack[off_slice]
+                l_greater_batch = self.l_greater.stack[off_slice]
 
                 # Change the block sizes to match the Coulomb matrix.
                 self._set_block_sizes(self.small_block_sizes)
 
             self._assemble_retarded_polarization(
-                p_lesser_tmp,
-                p_greater_tmp,
-                p_retarded_hermitian_tmp,
+                p_lesser_batch,
+                p_greater_batch,
+                p_retarded_hermitian_batch,
             )
 
             # Assemble the system matrix (Includes matrix multiplication).
@@ -791,10 +791,10 @@ class CoulombScreeningSolver(SubsystemSolver):
 
             # Apply the OBC algorithm.
             self._compute_obc(
-                p_lesser_tmp,
-                p_greater_tmp,
+                p_lesser_batch,
+                p_greater_batch,
                 self.p_retarded,
-                stack_slice,
+                batch_slice,
             )
             self.p_retarded.free_data()
 
@@ -808,21 +808,21 @@ class CoulombScreeningSolver(SubsystemSolver):
                 end_block = start_block + local_blocks[comm.block.rank]
                 bd_sandwich(
                     self.coulomb_matrix,
-                    p_lesser_tmp,
-                    out=l_lesser_tmp,
+                    p_lesser_batch,
+                    out=l_lesser_batch,
                     start_block=start_block,
                     end_block=end_block,
                 )
-                self._apply_spillover_sandwich(p_lesser_tmp, l_lesser_tmp)
+                self._apply_spillover_sandwich(p_lesser_batch, l_lesser_batch)
 
                 bd_sandwich(
                     self.coulomb_matrix,
-                    p_greater_tmp,
-                    out=l_greater_tmp,
+                    p_greater_batch,
+                    out=l_greater_batch,
                     start_block=start_block,
                     end_block=end_block,
                 )
-                self._apply_spillover_sandwich(p_greater_tmp, l_greater_tmp)
+                self._apply_spillover_sandwich(p_greater_batch, l_greater_batch)
 
             if self.flatband:
                 with profiler.profile_range(
@@ -831,8 +831,8 @@ class CoulombScreeningSolver(SubsystemSolver):
                     comm=comm,
                 ):
                     homogenize(self.system_matrix)
-                    homogenize(l_lesser_tmp)
-                    homogenize(l_greater_tmp)
+                    homogenize(l_lesser_batch)
+                    homogenize(l_greater_batch)
 
             with profiler.profile_range(
                 label="CoulombScreeningSolver: Set block sizes back",
@@ -847,16 +847,16 @@ class CoulombScreeningSolver(SubsystemSolver):
             ):
                 out_l, out_g = out
                 out_slice = (
-                    out_l.stack[stack_slice],
-                    out_g.stack[stack_slice],
+                    out_l.stack[batch_slice],
+                    out_g.stack[batch_slice],
                 )
 
                 # Solve the system
                 if comm.block.size > 1:
                     self.solver_dist.selected_solve(
                         a=self.system_matrix,
-                        sigma_lesser=l_lesser_tmp,
-                        sigma_greater=l_greater_tmp,
+                        sigma_lesser=l_lesser_batch,
+                        sigma_greater=l_greater_batch,
                         obc_blocks=self.obc_blocks,
                         out=out_slice,
                         return_retarded=False,
@@ -865,8 +865,8 @@ class CoulombScreeningSolver(SubsystemSolver):
                 else:
                     self.solver.selected_solve(
                         a=self.system_matrix,
-                        sigma_lesser=l_lesser_tmp,
-                        sigma_greater=l_greater_tmp,
+                        sigma_lesser=l_lesser_batch,
+                        sigma_greater=l_greater_batch,
                         obc_blocks=self.obc_blocks,
                         out=out_slice,
                         return_retarded=False,

--- a/src/quatrex/coulomb_screening/solver.py
+++ b/src/quatrex/coulomb_screening/solver.py
@@ -5,6 +5,7 @@ import numpy as np
 from qttools import NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
+from qttools.datastructures.dsdbsparse import _DStackView
 from qttools.datastructures.routines import bd_matmul, bd_sandwich
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler
@@ -210,9 +211,9 @@ class CoulombScreeningSolver(SubsystemSolver):
     def _compute_contact_obc(
         self,
         contact: str,
-        p_lesser: DSDBSparse,
-        p_greater: DSDBSparse,
-        p_retarded: DSDBSparse,
+        p_lesser: DSDBSparse | _DStackView,
+        p_greater: DSDBSparse | _DStackView,
+        p_retarded: DSDBSparse | _DStackView,
         diagonal_inds: tuple,
         upper_inds: tuple,
         order: str | NDArray | None = None,
@@ -224,11 +225,11 @@ class CoulombScreeningSolver(SubsystemSolver):
         contact : str
             The contact for which to compute the OBC.
             Used for profiling and caching purposes.
-        p_lesser : DSDBSparse
+        p_lesser : DSDBSparse | _DStackView
             The lesser polarization.
-        p_greater : DSDBSparse
+        p_greater : DSDBSparse | _DStackView
             The greater polarization.
-        p_retarded : DSDBSparse
+        p_retarded : DSDBSparse | _DStackView
             The retarded polarization.
         diagonal_inds : tuple
             The indices of the diagonal blocks corresponding to the contact.
@@ -378,9 +379,9 @@ class CoulombScreeningSolver(SubsystemSolver):
     @profiler.profile(label="CoulombScreeningSolver: OBC", level="default", comm=comm)
     def _compute_obc(
         self,
-        p_lesser: DSDBSparse,
-        p_greater: DSDBSparse,
-        p_retarded: DSDBSparse,
+        p_lesser: DSDBSparse | _DStackView,
+        p_greater: DSDBSparse | _DStackView,
+        p_retarded: DSDBSparse | _DStackView,
         batch_slice: slice,
     ) -> None:
         """Computes open boundary conditions (OBC).
@@ -401,11 +402,11 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         Parameters
         ----------
-        p_lesser : DSDBSparse
+        p_lesser : DSDBSparse | _DStackView
             The lesser polarization.
-        p_greater : DSDBSparse
+        p_greater : DSDBSparse | _DStackView
             The greater polarization.
-        p_retarded : DSDBSparse
+        p_retarded : DSDBSparse | _DStackView
             The retarded polarization.
         batch_slice : slice
             The slice of the energy stack corresponding to the current batch.
@@ -446,9 +447,9 @@ class CoulombScreeningSolver(SubsystemSolver):
     )
     def _assemble_retarded_polarization(
         self,
-        p_lesser: DSDBSparse,
-        p_greater: DSDBSparse,
-        p_retarded_hermitian: DSDBSparse,
+        p_lesser: DSDBSparse | _DStackView,
+        p_greater: DSDBSparse | _DStackView,
+        p_retarded_hermitian: DSDBSparse | _DStackView,
     ) -> None:
         r"""Assembles the full retarded polarization from the Hermitian part
         and the lesser and greater parts.
@@ -459,11 +460,11 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         Parameters
         ----------
-        p_lesser : DSDBSparse
+        p_lesser : DSDBSparse | _DStackView
             The lesser polarization.
-        p_greater : DSDBSparse
+        p_greater : DSDBSparse | _DStackView
             The greater polarization.
-        p_retarded_hermitian : DSDBSparse
+        p_retarded_hermitian : DSDBSparse | _DStackView
             The hermitian part of the retarded polarization.
 
         """
@@ -578,8 +579,8 @@ class CoulombScreeningSolver(SubsystemSolver):
 
     def _contact_spillover_sandwich(
         self,
-        p_: DSDBSparse,
-        l_: DSDBSparse,
+        p_: DSDBSparse | _DStackView,
+        l_: DSDBSparse | _DStackView,
         diagonal_inds: tuple,
         upper_inds: tuple,
         order: str | NDArray | None = None,
@@ -592,9 +593,9 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         Parameters
         ----------
-        p_ : DSDBSparse
+        p_ : DSDBSparse | _DStackView
             The polarization (either lesser or greater).
-        l_ : DSDBSparse
+        l_ : DSDBSparse | _DStackView
             The matrix to which the spillover correction will be applied (either
             `l_lesser` or `l_greater`).
         diagonal_inds : tuple
@@ -636,8 +637,8 @@ class CoulombScreeningSolver(SubsystemSolver):
 
     def _apply_spillover_sandwich(
         self,
-        p_: DSDBSparse,
-        l_: DSDBSparse,
+        p_: DSDBSparse | _DStackView,
+        l_: DSDBSparse | _DStackView,
     ) -> None:
         r"""Applies the spillover correction to
 
@@ -647,9 +648,9 @@ class CoulombScreeningSolver(SubsystemSolver):
 
         Parameters
         ----------
-        p_ : DSDBSparse
+        p_ : DSDBSparse | _DStackView
             The polarization (either lesser or greater).
-        l_ : DSDBSparse
+        l_ : DSDBSparse | _DStackView
             The matrix to which the spillover correction will be applied (either
             `l_lesser` or `l_greater`).
 
@@ -753,7 +754,6 @@ class CoulombScreeningSolver(SubsystemSolver):
         for i in range(len(batch_sizes)):
 
             batch_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
-            off_slice = slice(0, int(batch_offsets[i + 1] - batch_offsets[i]))
 
             # Free data when the batch size changes
             if i > 0 and batch_sizes[i] != batch_sizes[i - 1]:
@@ -774,8 +774,6 @@ class CoulombScreeningSolver(SubsystemSolver):
                 p_lesser_batch = p_lesser.stack[batch_slice]
                 p_greater_batch = p_greater.stack[batch_slice]
                 p_retarded_hermitian_batch = p_retarded_hermitian.stack[batch_slice]
-                l_lesser_batch = self.l_lesser.stack[off_slice]
-                l_greater_batch = self.l_greater.stack[off_slice]
 
                 # Change the block sizes to match the Coulomb matrix.
                 self._set_block_sizes(self.small_block_sizes)
@@ -809,20 +807,20 @@ class CoulombScreeningSolver(SubsystemSolver):
                 bd_sandwich(
                     self.coulomb_matrix,
                     p_lesser_batch,
-                    out=l_lesser_batch,
+                    out=self.l_lesser,
                     start_block=start_block,
                     end_block=end_block,
                 )
-                self._apply_spillover_sandwich(p_lesser_batch, l_lesser_batch)
+                self._apply_spillover_sandwich(p_lesser_batch, self.l_lesser)
 
                 bd_sandwich(
                     self.coulomb_matrix,
                     p_greater_batch,
-                    out=l_greater_batch,
+                    out=self.l_greater,
                     start_block=start_block,
                     end_block=end_block,
                 )
-                self._apply_spillover_sandwich(p_greater_batch, l_greater_batch)
+                self._apply_spillover_sandwich(p_greater_batch, self.l_greater)
 
             if self.flatband:
                 with profiler.profile_range(
@@ -831,8 +829,8 @@ class CoulombScreeningSolver(SubsystemSolver):
                     comm=comm,
                 ):
                     homogenize(self.system_matrix)
-                    homogenize(l_lesser_batch)
-                    homogenize(l_greater_batch)
+                    homogenize(self.l_lesser)
+                    homogenize(self.l_greater)
 
             with profiler.profile_range(
                 label="CoulombScreeningSolver: Set block sizes back",
@@ -855,8 +853,8 @@ class CoulombScreeningSolver(SubsystemSolver):
                 if comm.block.size > 1:
                     self.solver_dist.selected_solve(
                         a=self.system_matrix,
-                        sigma_lesser=l_lesser_batch,
-                        sigma_greater=l_greater_batch,
+                        sigma_lesser=self.l_lesser,
+                        sigma_greater=self.l_greater,
                         obc_blocks=self.obc_blocks,
                         out=out_slice,
                         return_retarded=False,
@@ -865,8 +863,8 @@ class CoulombScreeningSolver(SubsystemSolver):
                 else:
                     self.solver.selected_solve(
                         a=self.system_matrix,
-                        sigma_lesser=l_lesser_batch,
-                        sigma_greater=l_greater_batch,
+                        sigma_lesser=self.l_lesser,
+                        sigma_greater=self.l_greater,
                         obc_blocks=self.obc_blocks,
                         out=out_slice,
                         return_retarded=False,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -471,6 +471,7 @@ class ElectronSolver(SubsystemSolver):
                 + hamiltonian_.blocks[j, i]
             )
 
+    @profiler.profile(label="ElectronSolver: Assemble", level="default", comm=comm)
     def _assemble_system_matrix(
         self,
         sse_lesser: DSDBSparse | _DStackView,
@@ -592,7 +593,7 @@ class ElectronSolver(SubsystemSolver):
 
         if self.band_edge_tracking:
             with profiler.profile_range(
-                label="ElectronSolver: Assemble", level="default", comm=comm
+                label="ElectronSolver: Band edges", level="default", comm=comm
             ):
                 left_band_edges, right_band_edges = find_renormalized_eigenvalues(
                     hamiltonian=self.hamiltonian,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -302,21 +302,21 @@ class ElectronSolver(SubsystemSolver):
         )
 
     @profiler.profile(label="ElectronSolver: OBC", level="default", comm=comm)
-    def _compute_obc(self, stack_slice: slice) -> None:
+    def _compute_obc(self, batch_slice: slice) -> None:
         """Computes open boundary conditions.
 
         Parameters
         ----------
-        stack_slice : slice
+        batch_slice : slice
             The slice of the energy stack corresponding to the current batch.
 
         """
         if comm.block.rank == 0:
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="left-" + str(stack_slice),
+                contact="left-" + str(batch_slice),
                 diagonal_inds=(0, 0),
                 upper_inds=(0, 1),
-                occupancies=self.left_occupancies[stack_slice],
+                occupancies=self.left_occupancies[batch_slice],
             )
             self.obc_blocks.retarded[0] = obc_retarded
             self.obc_blocks.lesser[0] = obc_lesser
@@ -326,10 +326,10 @@ class ElectronSolver(SubsystemSolver):
             n = self.system_matrix.num_local_blocks - 1
             m = n - 1
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="right-" + str(stack_slice),
+                contact="right-" + str(batch_slice),
                 diagonal_inds=(n, n),
                 upper_inds=(n, m),
-                occupancies=self.right_occupancies[stack_slice],
+                occupancies=self.right_occupancies[batch_slice],
                 order="reverse",
             )
             self.obc_blocks.retarded[-1] = obc_retarded
@@ -476,7 +476,7 @@ class ElectronSolver(SubsystemSolver):
         sse_lesser: DSDBSparse | _DStackView,
         sse_greater: DSDBSparse | _DStackView,
         sse_retarded_hermitian: DSDBSparse | _DStackView,
-        stack_slice: slice,
+        batch_slice: slice,
     ) -> None:
         """Assembles the system matrix.
 
@@ -488,7 +488,7 @@ class ElectronSolver(SubsystemSolver):
             The greater scattering self-energy.
         sse_retarded_hermitian : DSDBSparse | _DStackView
             The hermitian part of the retarded scattering self-energy.
-        stack_slice : slice
+        batch_slice : slice
             The slice of the energy stack corresponding to the current batch.
 
         """
@@ -500,7 +500,7 @@ class ElectronSolver(SubsystemSolver):
 
         scale_stack(
             self.system_matrix.data,
-            self.local_energies[stack_slice] + 1j * self.eta,
+            self.local_energies[batch_slice] + 1j * self.eta,
         )
 
         if self.overlap is None:
@@ -623,10 +623,10 @@ class ElectronSolver(SubsystemSolver):
 
         for i in range(len(batch_sizes)):
 
-            stack_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
-            sse_lesser_tmp = sse_lesser.stack[stack_slice]
-            sse_greater_tmp = sse_greater.stack[stack_slice]
-            sse_retarded_hermitian_tmp = sse_retarded_hermitian.stack[stack_slice]
+            batch_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
+            sse_lesser_batch = sse_lesser.stack[batch_slice]
+            sse_greater_batch = sse_greater.stack[batch_slice]
+            sse_retarded_hermitian_batch = sse_retarded_hermitian.stack[batch_slice]
 
             # Free data when the batch size changes
             if i > 0 and batch_sizes[i] != batch_sizes[i - 1]:
@@ -634,26 +634,29 @@ class ElectronSolver(SubsystemSolver):
             self.system_matrix.allocate_data(stack_size=batch_sizes[i])
 
             self._assemble_system_matrix(
-                sse_lesser_tmp, sse_greater_tmp, sse_retarded_hermitian_tmp, stack_slice
+                sse_lesser_batch,
+                sse_greater_batch,
+                sse_retarded_hermitian_batch,
+                batch_slice,
             )
 
-            self._compute_obc(stack_slice)
+            self._compute_obc(batch_slice)
 
             with profiler.profile_range(
                 label="ElectronSolver: Solve", level="default", comm=comm
             ):
                 out_l, out_g, out_r = out
                 out_slice = (
-                    out_l.stack[stack_slice],
-                    out_g.stack[stack_slice],
-                    out_r.stack[stack_slice],
+                    out_l.stack[batch_slice],
+                    out_g.stack[batch_slice],
+                    out_r.stack[batch_slice],
                 )
                 if comm.block.size > 1:
                     self.meir_wingreen_current.append(
                         self.solver_dist.selected_solve(
                             a=self.system_matrix,
-                            sigma_lesser=sse_lesser_tmp,
-                            sigma_greater=sse_greater_tmp,
+                            sigma_lesser=sse_lesser_batch,
+                            sigma_greater=sse_greater_batch,
                             obc_blocks=self.obc_blocks,
                             out=out_slice,
                             return_retarded=True,
@@ -665,8 +668,8 @@ class ElectronSolver(SubsystemSolver):
                     self.meir_wingreen_current.append(
                         self.solver.selected_solve(
                             a=self.system_matrix,
-                            sigma_lesser=sse_lesser_tmp,
-                            sigma_greater=sse_greater_tmp,
+                            sigma_lesser=sse_lesser_batch,
+                            sigma_greater=sse_greater_batch,
                             obc_blocks=self.obc_blocks,
                             out=out_slice,
                             return_retarded=True,

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -628,6 +628,9 @@ class ElectronSolver(SubsystemSolver):
             sse_greater_tmp = sse_greater.stack[stack_slice]
             sse_retarded_hermitian_tmp = sse_retarded_hermitian.stack[stack_slice]
 
+            # Free data when the batch size changes
+            if i > 0 and batch_sizes[i] != batch_sizes[i - 1]:
+                self.system_matrix.free_data()
             self.system_matrix.allocate_data(stack_size=batch_sizes[i])
 
             self._assemble_system_matrix(

--- a/src/quatrex/electron/solver.py
+++ b/src/quatrex/electron/solver.py
@@ -5,10 +5,12 @@ import numpy as np
 from qttools import NDArray, sparse, xp
 from qttools.comm import comm
 from qttools.datastructures import DSDBSparse
+from qttools.datastructures.dsdbsparse import _DStackView
 from qttools.greens_function_solver.solver import OBCBlocks
 from qttools.profiling import Profiler
 from qttools.toeplitz.toeplitz import get_periodic_superblocks, homogenize
 from qttools.utils.mpi_utils import get_local_slice, get_section_sizes
+from qttools.utils.solvers_utils import get_batches
 from qttools.utils.stack_utils import scale_stack
 from quatrex.bandstructure.band_edges import find_renormalized_eigenvalues
 from quatrex.core.config import QuatrexConfig
@@ -164,6 +166,8 @@ class ElectronSolver(SubsystemSolver):
         self.call_count = 0
         self.filtering_iteration_limit = config.electron.filtering_iteration_limit
 
+        self.max_batch_size = config.electron.max_batch_size
+
     def update_potential(self, new_potential: NDArray) -> None:
         """Updates the potential matrix.
 
@@ -298,14 +302,21 @@ class ElectronSolver(SubsystemSolver):
         )
 
     @profiler.profile(label="ElectronSolver: OBC", level="default", comm=comm)
-    def _compute_obc(self) -> None:
-        """Computes open boundary conditions."""
+    def _compute_obc(self, stack_slice: slice) -> None:
+        """Computes open boundary conditions.
+
+        Parameters
+        ----------
+        stack_slice : slice
+            The slice of the energy stack corresponding to the current batch.
+
+        """
         if comm.block.rank == 0:
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="left",
+                contact="left-" + str(stack_slice),
                 diagonal_inds=(0, 0),
                 upper_inds=(0, 1),
-                occupancies=self.left_occupancies,
+                occupancies=self.left_occupancies[stack_slice],
             )
             self.obc_blocks.retarded[0] = obc_retarded
             self.obc_blocks.lesser[0] = obc_lesser
@@ -315,10 +326,10 @@ class ElectronSolver(SubsystemSolver):
             n = self.system_matrix.num_local_blocks - 1
             m = n - 1
             obc_retarded, obc_lesser, obc_greater = self._compute_contact_obc(
-                contact="right",
+                contact="right-" + str(stack_slice),
                 diagonal_inds=(n, n),
                 upper_inds=(n, m),
-                occupancies=self.right_occupancies,
+                occupancies=self.right_occupancies[stack_slice],
                 order="reverse",
             )
             self.obc_blocks.retarded[-1] = obc_retarded
@@ -406,9 +417,9 @@ class ElectronSolver(SubsystemSolver):
 
     def _subtract_hamiltonian_and_self_energy(
         self,
-        sse_lesser: DSDBSparse,
-        sse_greater: DSDBSparse,
-        sse_retarded_hermitian: DSDBSparse,
+        sse_lesser: DSDBSparse | _DStackView,
+        sse_greater: DSDBSparse | _DStackView,
+        sse_retarded_hermitian: DSDBSparse | _DStackView,
     ) -> None:
         r"""Subtracts the Hamiltonian and the self-energy from the system matrix
         on the block-tridiagonal.
@@ -421,11 +432,11 @@ class ElectronSolver(SubsystemSolver):
 
         Parameters
         ----------
-        sse_lesser : DSDBSparse
+        sse_lesser : DSDBSparse | _DStackView
             The lesser self-energy to subtract.
-        sse_greater : DSDBSparse
+        sse_greater : DSDBSparse | _DStackView
             The greater self-energy to subtract.
-        sse_retarded_hermitian : DSDBSparse
+        sse_retarded_hermitian : DSDBSparse | _DStackView
             The retarded self-energy to subtract.
 
         """
@@ -462,20 +473,23 @@ class ElectronSolver(SubsystemSolver):
 
     def _assemble_system_matrix(
         self,
-        sse_lesser: DSDBSparse,
-        sse_greater: DSDBSparse,
-        sse_retarded_hermitian: DSDBSparse,
+        sse_lesser: DSDBSparse | _DStackView,
+        sse_greater: DSDBSparse | _DStackView,
+        sse_retarded_hermitian: DSDBSparse | _DStackView,
+        stack_slice: slice,
     ) -> None:
         """Assembles the system matrix.
 
         Parameters
         ----------
-        sse_lesser : DSDBSparse
+        sse_lesser : DSDBSparse | _DStackView
             The lesser scattering self-energy.
-        sse_greater : DSDBSparse
+        sse_greater : DSDBSparse | _DStackView
             The greater scattering self-energy.
-        sse_retarded_hermitian : DSDBSparse
+        sse_retarded_hermitian : DSDBSparse | _DStackView
             The hermitian part of the retarded scattering self-energy.
+        stack_slice : slice
+            The slice of the energy stack corresponding to the current batch.
 
         """
         self.system_matrix.data = 0.0
@@ -486,7 +500,7 @@ class ElectronSolver(SubsystemSolver):
 
         scale_stack(
             self.system_matrix.data,
-            self.local_energies + 1j * self.eta,
+            self.local_energies[stack_slice] + 1j * self.eta,
         )
 
         if self.overlap is None:
@@ -576,18 +590,9 @@ class ElectronSolver(SubsystemSolver):
                 homogenize(sse_lesser)
                 homogenize(sse_retarded_hermitian)
 
-        with profiler.profile_range(
-            label="ElectronSolver: Assemble", level="default", comm=comm
-        ):
-            self.system_matrix.allocate_data()
-
-            self._assemble_system_matrix(
-                sse_lesser, sse_greater, sse_retarded_hermitian
-            )
-
         if self.band_edge_tracking:
             with profiler.profile_range(
-                label="ElectronSolver: Band edges", level="default", comm=comm
+                label="ElectronSolver: Assemble", level="default", comm=comm
             ):
                 left_band_edges, right_band_edges = find_renormalized_eigenvalues(
                     hamiltonian=self.hamiltonian,
@@ -607,32 +612,64 @@ class ElectronSolver(SubsystemSolver):
                 )
                 self._update_fermi_levels(left_band_edges, right_band_edges)
 
-        self._compute_obc()
+        if self.max_batch_size is None:
+            max_batch_size = sse_lesser.shape[0]
+        else:
+            max_batch_size = self.max_batch_size
 
-        with profiler.profile_range(
-            label="ElectronSolver: Solve", level="default", comm=comm
-        ):
-            if comm.block.size > 1:
-                self.meir_wingreen_current = self.solver_dist.selected_solve(
-                    a=self.system_matrix,
-                    sigma_lesser=sse_lesser,
-                    sigma_greater=sse_greater,
-                    obc_blocks=self.obc_blocks,
-                    out=out,
-                    return_retarded=True,
-                    return_current=self.compute_meir_wingreen_current,
-                )
+        batch_sizes, batch_offsets = get_batches(sse_lesser.shape[0], max_batch_size)
 
-            else:
-                self.meir_wingreen_current = self.solver.selected_solve(
-                    a=self.system_matrix,
-                    sigma_lesser=sse_lesser,
-                    sigma_greater=sse_greater,
-                    obc_blocks=self.obc_blocks,
-                    out=out,
-                    return_retarded=True,
-                    return_current=self.compute_meir_wingreen_current,
+        self.meir_wingreen_current = []
+
+        for i in range(len(batch_sizes)):
+
+            stack_slice = slice(int(batch_offsets[i]), int(batch_offsets[i + 1]))
+            sse_lesser_tmp = sse_lesser.stack[stack_slice]
+            sse_greater_tmp = sse_greater.stack[stack_slice]
+            sse_retarded_hermitian_tmp = sse_retarded_hermitian.stack[stack_slice]
+
+            self.system_matrix.allocate_data(stack_size=batch_sizes[i])
+
+            self._assemble_system_matrix(
+                sse_lesser_tmp, sse_greater_tmp, sse_retarded_hermitian_tmp, stack_slice
+            )
+
+            self._compute_obc(stack_slice)
+
+            with profiler.profile_range(
+                label="ElectronSolver: Solve", level="default", comm=comm
+            ):
+                out_l, out_g, out_r = out
+                out_slice = (
+                    out_l.stack[stack_slice],
+                    out_g.stack[stack_slice],
+                    out_r.stack[stack_slice],
                 )
+                if comm.block.size > 1:
+                    self.meir_wingreen_current.append(
+                        self.solver_dist.selected_solve(
+                            a=self.system_matrix,
+                            sigma_lesser=sse_lesser_tmp,
+                            sigma_greater=sse_greater_tmp,
+                            obc_blocks=self.obc_blocks,
+                            out=out_slice,
+                            return_retarded=True,
+                            return_current=self.compute_meir_wingreen_current,
+                        )
+                    )
+
+                else:
+                    self.meir_wingreen_current.append(
+                        self.solver.selected_solve(
+                            a=self.system_matrix,
+                            sigma_lesser=sse_lesser_tmp,
+                            sigma_greater=sse_greater_tmp,
+                            obc_blocks=self.obc_blocks,
+                            out=out_slice,
+                            return_retarded=True,
+                            return_current=self.compute_meir_wingreen_current,
+                        )
+                    )
 
         with profiler.profile_range(
             label="ElectronSolver: Filter", level="default", comm=comm
@@ -640,5 +677,10 @@ class ElectronSolver(SubsystemSolver):
             self.system_matrix.free_data()
             if self.call_count < self.filtering_iteration_limit:
                 self._filter_peaks(out)
+
+        if self.compute_meir_wingreen_current:
+            self.meir_wingreen_current = xp.concatenate(
+                self.meir_wingreen_current, axis=0
+            )
 
         self.call_count += 1


### PR DESCRIPTION
This PR should solve issue #255.
Partial batching is implemented in both the electron and the coulomb solvers.
This is done by extending the dataclass to enable views of views.
The result is a bit cooked, but we hopefully clean it up with #222.

This PR will be followed up by other PRs to include the other optimizations from SC25. I believe this should be done before refactoring the `dsdbsparse`.
