### PR TITLE
Update CI

### DIFF
--- a/.cscs/alps-ci.yaml
+++ b/.cscs/alps-ci.yaml
@@ -42,22 +42,22 @@ build quatrex:
     SLURM_NTASKS: 1
     SLURM_GPUS_PER_TASK: 1
     SLURM_TIMELIMIT: '00:20:00'
-    SLURM_PARTITION: debug
+    SLURM_PARTITION: normal
 
 test quatrex single:
   extends: .test-common
   script:
-    - coverage run --source=src --parallel-mode -m pytest tests/quatrex
+    - coverage run --source=src --parallel-mode -m pytest -vv tests/quatrex
 
 test qttools single:
   extends: .test-common
   script:
-    - coverage run --source=src --parallel-mode -m pytest tests/qttools
+    - coverage run --source=src --parallel-mode -m pytest -vv tests/qttools
 
 test quatrex dist:
   extends: .test-common
   script:
-    - coverage run --source=src --parallel-mode -m pytest --only-mpi tests/quatrex
+    - coverage run --source=src --parallel-mode -m pytest -vv --only-mpi tests/quatrex
   variables:
     SLURM_JOB_NUM_NODES: 2
     SLURM_NTASKS: 6
@@ -65,7 +65,7 @@ test quatrex dist:
 test qttools dist:
   extends: .test-common
   script:
-    - coverage run --source=src --parallel-mode -m pytest --only-mpi tests/qttools
+    - coverage run --source=src --parallel-mode -m pytest -vv --only-mpi tests/qttools
   variables:
     SLURM_JOB_NUM_NODES: 2
     SLURM_NTASKS: 6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,24 +38,24 @@ jobs:
 
       - name: Run QTTools MPI Tests
         run: |
-          NUMBA_DISABLE_JIT=1 mpiexec -np 6 coverage run --source=src --parallel-mode -m pytest -x --only-mpi tests/qttools
+          NUMBA_DISABLE_JIT=1 mpiexec -np 3 coverage run --source=src --parallel-mode -m pytest -vv --only-mpi tests/qttools
 
       - name: Run QuaTrEx MPI Tests
         run: |
-          NUMBA_DISABLE_JIT=1 mpiexec -np 6 coverage run --source=src --parallel-mode -m pytest -x --only-mpi tests/quatrex
+          NUMBA_DISABLE_JIT=1 mpiexec -np 3 coverage run --source=src --parallel-mode -m pytest -vv --only-mpi tests/quatrex
 
       - name: Run NUMBA Tests (QTTools Kernels)
         if: success() || failure()
         run: |
-          coverage run --source=src --parallel-mode -m pytest tests/qttools/kernels
+          coverage run --source=src --parallel-mode -m pytest -vv tests/qttools/kernels
 
       - name: Run QTTools Tests
         if: success() || failure()
         run: |
-          NUMBA_DISABLE_JIT=1 coverage run --source=src --parallel-mode -m pytest tests/qttools
+          NUMBA_DISABLE_JIT=1 coverage run --source=src --parallel-mode -m pytest -vv tests/qttools
       
       - name: Run QuaTrEx Tests and Determine Coverage
         if: success() || failure()
         run: |
-          coverage run --source=src --parallel-mode -m pytest tests/quatrex
+          coverage run --source=src --parallel-mode -m pytest -vv tests/quatrex
           coverage combine .; coverage report; coverage xml


### PR DESCRIPTION
- The Alps CI is now on the normal queue since there is a job limit on the debug queue.
- Remove `-x` from the tests to remove deadlocks in the MPI tests.
- Add `-vv` to the tests for more debug information.
- Reduce the number of ranks on the GitHub runner from 6 to 3 since there are only 4 cores.