### PR TITLE
Added printing of electron energy grid

### DIFF
--- a/examples/cp2k/carbon-chain/phonon/reference-outputs/electron_energies.npy
+++ b/examples/cp2k/carbon-chain/phonon/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9b0f0c4bb608a1d5a61e4f6e3ca7dd57ee9b662662041a69fd89d391031dda
+size 208

--- a/examples/cp2k/carbon-chain/qtbm-low-rank/reference-outputs/electron_energies.npy
+++ b/examples/cp2k/carbon-chain/qtbm-low-rank/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9b0f0c4bb608a1d5a61e4f6e3ca7dd57ee9b662662041a69fd89d391031dda
+size 208

--- a/examples/cp2k/carbon-chain/qtbm/reference-outputs/electron_energies.npy
+++ b/examples/cp2k/carbon-chain/qtbm/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9b0f0c4bb608a1d5a61e4f6e3ca7dd57ee9b662662041a69fd89d391031dda
+size 208

--- a/examples/cp2k/graphene/qtbm-low-rank/reference-outputs/electron_energies.npy
+++ b/examples/cp2k/graphene/qtbm-low-rank/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9b0f0c4bb608a1d5a61e4f6e3ca7dd57ee9b662662041a69fd89d391031dda
+size 208

--- a/examples/cp2k/graphene/qtbm/reference-outputs/electron_energies.npy
+++ b/examples/cp2k/graphene/qtbm/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d9b0f0c4bb608a1d5a61e4f6e3ca7dd57ee9b662662041a69fd89d391031dda
+size 208

--- a/examples/w90/carbon-nanotube/gw-dist/reference-outputs/electron_energies.npy
+++ b/examples/w90/carbon-nanotube/gw-dist/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2bd4b1aa2f368c94f7d48358b6c9745a05d8b895565d3ef7dd3dc134bd65ac
+size 928

--- a/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_energies.npy
+++ b/examples/w90/carbon-nanotube/gw-unit-cell/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2bd4b1aa2f368c94f7d48358b6c9745a05d8b895565d3ef7dd3dc134bd65ac
+size 928

--- a/examples/w90/carbon-nanotube/gw/reference-outputs/electron_energies.npy
+++ b/examples/w90/carbon-nanotube/gw/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2bd4b1aa2f368c94f7d48358b6c9745a05d8b895565d3ef7dd3dc134bd65ac
+size 928

--- a/examples/w90/carbon-nanotube/qtbm-poisson/reference-outputs/electron_energies.npy
+++ b/examples/w90/carbon-nanotube/qtbm-poisson/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:413e21df7459fbe89c12a400e4f5fe9dc100d3f79bafcb5d25d37f5b82707f15
+size 928

--- a/examples/w90/carbon-nanotube/qtbm/reference-outputs/electron_energies.npy
+++ b/examples/w90/carbon-nanotube/qtbm/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f391bbd265abb3569266a6b7848621ceb2561a047c41327bef92e8144a4a7814
+size 208

--- a/examples/w90/mos2/gw-kpoints/reference-outputs/electron_energies.npy
+++ b/examples/w90/mos2/gw-kpoints/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d592a5c96eb6e349d0adda3af4ced37c5399df7e11d80737f7021eb0c09f237
+size 928

--- a/examples/w90/si-bulk/qtbm-low-rank/reference-outputs/electron_energies.npy
+++ b/examples/w90/si-bulk/qtbm-low-rank/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9856b8683cb8c9f4eabc582a1af6ede68db35bca56e2b14ad109e8cbcd7018cf
+size 208

--- a/examples/w90/si-bulk/qtbm/reference-outputs/electron_energies.npy
+++ b/examples/w90/si-bulk/qtbm/reference-outputs/electron_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9856b8683cb8c9f4eabc582a1af6ede68db35bca56e2b14ad109e8cbcd7018cf
+size 208

--- a/src/quatrex/grid/energies.py
+++ b/src/quatrex/grid/energies.py
@@ -67,4 +67,9 @@ def get_electron_energies(config: QuatrexConfig) -> NDArray:
             raise FileNotFoundError(
                 f"Could not find electron energies file at {energies_path}. Please provide an energy window in the config."
             )
+
+    if not os.path.exists(config.output_dir):
+        os.mkdir(config.output_dir)
+    xp.save(config.output_dir / "electron_energies.npy", electron_energies)
+
     return electron_energies


### PR DESCRIPTION
Adds a line in `get_electron_energies` to save the electron energy grid as `electron_energies.npy` in the output directory. This makes the energy grid available for post-processing.