### PR TITLE
Bump version of github CI repo checkout action

### DIFF
--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -13,7 +13,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set Up C++ Compiler
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Pull Necessary LFS Files
         run: git lfs pull --exclude="*.h5, *.npy, *.msh"

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -26,6 +26,12 @@ jobs:
           frozen: true
           activate-environment: ci
 
+      - name: Check repo commit and the quatrex version in pixi
+        run: |
+          echo "Commit hash: $(git rev-parse HEAD)"
+          echo "quatrex version: $(python -c 'import quatrex; print(quatrex.__version__)')"
+
+
       - name: Run Pre-Commit Hooks
         id: pre-commit
         continue-on-error: true

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -18,19 +18,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set Up Pixi
         uses: prefix-dev/setup-pixi@v0.10.0
         with:
           frozen: true
           activate-environment: ci
-
-      - name: Check repo commit and the quatrex version in pixi
-        run: |
-          echo "Commit hash: $(git rev-parse HEAD)"
-          echo "quatrex version: $(python -c 'import quatrex; print(quatrex.__version__)')"
-
 
       - name: Run Pre-Commit Hooks
         id: pre-commit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Pull LFS Files
         run: git lfs pull

--- a/src/quatrex/__about__.py
+++ b/src/quatrex/__about__.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the quatrex package.
 
-__version__ = "2.0.1"
+__version__ = "0.0.1"

--- a/src/quatrex/__about__.py
+++ b/src/quatrex/__about__.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2024-2026 ETH Zurich and the authors of the quatrex package.
 
-__version__ = "0.0.1"
+__version__ = "2.0.1"


### PR DESCRIPTION
Trying to reproduce the pixi caching bug from #350 in the linting CI here first. If it is indeed using the cached quatrex rather than the correct one, i'll change the `ci` pixi env not to include the repo by default.